### PR TITLE
Expose rise and fall healthchk options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ config/settings.yml
 releases/*.tgz
 releases/**/*.tgz
 ci/scripts/stemcell/*.tgz
+ci/scripts/stemcell-xenial/*.tgz
 ci/scripts/bpm/*.tgz
 dev_releases
 blobs/*

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -330,6 +330,8 @@ properties:
           backend_use_http_health:  true    # optional, defaults to false. enables http based health checks for the backend
           backend_http_health_port: 80      # optional, defaults to the port of the backend server. sets the port for the http backend health check
           backend_http_health_uri:  /health # optional, defaults to /health. sets the URI for backend http health checks
+          backend_health_fall: 3  # optional, defaults to 3 if not set. Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state.
+          backend_health_rise: 2  # optional, defaults to 2 if not set. Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state.
 
   ha_proxy.headers:
     description: "Hash of custom headers you wish you have set on each request. Spaces are automatically escaped, but any other haproxy delimiters will need to be escaped manually"
@@ -608,10 +610,10 @@ properties:
     description: Port to check the backend health on
     default: 8080
   ha_proxy.backend_health_fall:
-    description: Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a  healthy state. The default value of 3 matches the default if the parameter is undefined.
+    description: Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state. The default value of 3 matches the default if the parameter is undefined.
     default: 3
   ha_proxy.backend_health_rise:
-    description: Number of consecutive sucessful health checks required before the server is considered healthy from an unhealthy state. The default value of 2 matches the default if the parameter is undefined.
+    description: Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state. The default value of 2 matches the default if the parameter is undefined.
     default: 2
 
   ha_proxy.global_config:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -607,6 +607,12 @@ properties:
   ha_proxy.backend_http_health_port:
     description: Port to check the backend health on
     default: 8080
+  ha_proxy.backend_health_fall:
+    description: Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a  healthy state. The default value of 3 matches the default if the parameter is undefined.
+    default: 3
+  ha_proxy.backend_health_rise:
+    description: Number of consecutive sucessful health checks required before the server is considered healthy from an unhealthy state. The default value of 2 matches the default if the parameter is undefined.
+    default: 2
 
   ha_proxy.global_config:
     description: |

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -330,8 +330,8 @@ properties:
           backend_use_http_health:  true    # optional, defaults to false. enables http based health checks for the backend
           backend_http_health_port: 80      # optional, defaults to the port of the backend server. sets the port for the http backend health check
           backend_http_health_uri:  /health # optional, defaults to /health. sets the URI for backend http health checks
-          backend_health_fall: 3  # optional, defaults to 3 if not set. Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state.
-          backend_health_rise: 2  # optional, defaults to 2 if not set. Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state.
+          backend_health_fall: 3  # optional, ignored if backend_use_http_health is false. Defaults to 3 if not set. Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state.
+          backend_health_rise: 2  # optional, ignored if backend_use_http_health is false. Defaults to 2 if not set. Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state.
 
   ha_proxy.headers:
     description: "Hash of custom headers you wish you have set on each request. Spaces are automatically escaped, but any other haproxy delimiters will need to be escaped manually"
@@ -610,10 +610,10 @@ properties:
     description: Port to check the backend health on
     default: 8080
   ha_proxy.backend_health_fall:
-    description: Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state. The default value of 3 matches the default if the parameter is undefined.
+    description: Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state. The default value of 3 matches the default if the parameter is undefined. This parameter will be ignored if ha_proxy.backend_use_http_health is false.
     default: 3
   ha_proxy.backend_health_rise:
-    description: Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state. The default value of 2 matches the default if the parameter is undefined.
+    description: Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state. The default value of 2 matches the default if the parameter is undefined. This parameter will be ignored if ha_proxy.backend_use_http_health is false.
     default: 2
 
   ha_proxy.global_config:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -791,10 +791,16 @@ backend http-routed-backend-<%= prefix_hash %>
     <%- data["backend_http_health_port"] ||= data["port"] -%>
     <%- data["backend_http_health_uri"] ||= "/health" -%>
     option httpchk GET <%= data["backend_http_health_uri"] %>
-    <%- routed_health_check_options = "port " + data["backend_http_health_port"].to_s -%>
+    <%- routed_health_check_options = " port " + data["backend_http_health_port"].to_s -%>
+    <%- if data["backend_health_fall"] -%>
+      <%- routed_health_check_options += " fall " + data["backend_health_fall"].to_s -%>
+    <%- end -%>
+    <%- if data["backend_health_rise"] -%>
+      <%- routed_health_check_options += " rise " + data["backend_health_rise"].to_s -%>
+    <%- end -%>
   <%- end -%>
   <% data["servers"].each_with_index do |ip, index| %>
-    server node<%= index %> <%= ip %>:<%= data["port"] %> <%= resolvers -%>check inter 1000 <%= routed_health_check_options %> <%= backend_ssl %>
+    server node<%= index %> <%= ip %>:<%= data["port"] %> <%= resolvers -%>check inter 1000<%= routed_health_check_options %> <%= backend_ssl %>
   <% end %>
 <% end -%>
 # }}}

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -738,6 +738,8 @@ backend <%= backend[:name] %>
   <%- if p("ha_proxy.backend_use_http_health") == true  -%>
     option httpchk GET <%= p("ha_proxy.backend_http_health_uri") %>
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
+    <%- health_check_options += " fall " + p("ha_proxy.backend_health_fall").to_s -%>
+    <%- health_check_options += " rise " + p("ha_proxy.backend_health_rise").to_s -%>
   <%- end -%>
   <% backend_servers.each_with_index do |ip, index| %>
     server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend[:backend_ssl] %><%= backend[:alpn] %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip)  -%> backup<%- end -%>

--- a/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
@@ -109,6 +109,25 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
       end
     end
 
+    context 'when backend_health_fall and backend_health_rise is provided' do
+      let(:properties) do
+        default_properties.deep_merge({
+          'routed_backend_servers' => {
+            '/images' => {
+              'backend_use_http_health' => true,
+              'backend_health_fall' => 3,
+              'backend_health_rise' => 2
+            }
+          }
+        })
+      end
+
+      it 'configures the correct check rise and fall on the servers' do
+        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 port 443 fall 3 rise 2')
+        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 port 443 fall 3 rise 2')
+      end
+    end
+
     context 'when backend_http_health_uri is provided' do
       let(:properties) do
         default_properties.deep_merge({
@@ -139,8 +158,8 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
     end
 
     it 'configures the server to use ssl: verify' do
-      expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem')
-      expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem')
+      expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem')
+      expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem')
     end
 
     context 'when ha_proxy.enable_http2 is true' do
@@ -156,8 +175,8 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
       end
 
       it 'enables h2 ALPN negotiation with routed backends' do
-        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem alpn h2,http/1.1')
-        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem alpn h2,http/1.1')
+        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem alpn h2,http/1.1')
+        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem alpn h2,http/1.1')
       end
     end
 
@@ -174,8 +193,8 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
       end
 
       it 'configures the server to use ssl: verify with verifyhost for the provided host name' do
-        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
-        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
+        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
+        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
       end
 
       context 'when backend_ssl is not verify' do
@@ -211,8 +230,8 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
     end
 
     it 'configures the server to use ssl: verify none' do
-      expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000  ssl verify none')
-      expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000  ssl verify none')
+      expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 ssl verify none')
+      expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 ssl verify none')
     end
 
     context 'when ha_proxy.enable_http2 is true' do
@@ -228,8 +247,8 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
       end
 
       it 'enables h2 ALPN negotiation with routed backends' do
-        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000  ssl verify none alpn h2,http/1.1')
-        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000  ssl verify none alpn h2,http/1.1')
+        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 ssl verify none alpn h2,http/1.1')
+        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 ssl verify none alpn h2,http/1.1')
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
@@ -109,7 +109,43 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
       end
     end
 
-    context 'when backend_health_fall and backend_health_rise is provided' do
+    context 'when backend_health_fall is provided' do
+      let(:properties) do
+        default_properties.deep_merge({
+          'routed_backend_servers' => {
+            '/images' => {
+              'backend_use_http_health' => true,
+              'backend_health_fall' => 3
+            }
+          }
+        })
+      end
+
+      it 'configures the correct check rise and fall on the servers' do
+        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 port 443 fall 3')
+        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 port 443 fall 3')
+      end
+    end
+
+    context 'when backend_health_rise is provided' do
+      let(:properties) do
+        default_properties.deep_merge({
+          'routed_backend_servers' => {
+            '/images' => {
+              'backend_use_http_health' => true,
+              'backend_health_rise' => 2
+            }
+          }
+        })
+      end
+
+      it 'configures the correct check rise and fall on the servers' do
+        expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 port 443 rise 2')
+        expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 port 443 rise 2')
+      end
+    end
+
+    context 'when backend_health_fall and backend_rise is provided' do
       let(:properties) do
         default_properties.deep_merge({
           'routed_backend_servers' => {

--- a/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
@@ -58,7 +58,7 @@ describe 'config/haproxy.config backend http-routers' do
     let(:properties) do
       {
         'backend_use_http_health' => true,
-        'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+        'backend_servers' => ['10.0.0.1', '10.0.0.2']
       }
     end
 

--- a/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
@@ -58,7 +58,7 @@ describe 'config/haproxy.config backend http-routers' do
     let(:properties) do
       {
         'backend_use_http_health' => true,
-        'backend_servers' => ['10.0.0.1', '10.0.0.2']
+        'backend_servers' => ['10.0.0.1', '10.0.0.2'],
       }
     end
 
@@ -67,8 +67,8 @@ describe 'config/haproxy.config backend http-routers' do
     end
 
     it 'adds the healthcheck to the server config' do
-      expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8080')
-      expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080')
+      expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8080 fall 3 rise 2')
+      expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080 fall 3 rise 2')
     end
 
     context 'when backend_http_health_uri is provided' do
@@ -85,8 +85,8 @@ describe 'config/haproxy.config backend http-routers' do
       end
 
       it 'adds the healthcheck to the server config' do
-        expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8080')
-        expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080')
+        expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8080 fall 3 rise 2')
+        expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080 fall 3 rise 2')
       end
     end
 
@@ -104,8 +104,46 @@ describe 'config/haproxy.config backend http-routers' do
       end
 
       it 'adds the healthcheck to the server config' do
-        expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8081')
-        expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8081')
+        expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8081 fall 3 rise 2')
+        expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8081 fall 3 rise 2')
+      end
+    end
+
+    context 'when backend_health_fall is provided' do
+      let(:properties) do
+        {
+          'backend_use_http_health' => true,
+          'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+          'backend_health_fall' => 42
+        }
+      end
+
+      it 'configures the healthcheck' do
+        expect(backend_http1).to include('option httpchk GET /health')
+      end
+
+      it 'configures the servers' do
+        expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8080 fall 42 rise 2')
+        expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080 fall 42 rise 2')
+      end
+    end
+
+    context 'when backend_health_rise is provided' do
+      let(:properties) do
+        {
+          'backend_use_http_health' => true,
+          'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+          'backend_health_rise' => 99
+        }
+      end
+
+      it 'configures the healthcheck' do
+        expect(backend_http1).to include('option httpchk GET /health')
+      end
+
+      it 'configures the servers' do
+        expect(backend_http1).to include('server node0 10.0.0.1:80 check inter 1000 port 8080 fall 3 rise 99')
+        expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080 fall 3 rise 99')
       end
     end
   end


### PR DESCRIPTION
Adds new properties `backend_health_fall` and `backend_health_rise` for backend health checks.

Currently rise and fall are not set on the backend server health checks. If the parameters are not set, HAProxy defaults the values to `fall 3 rise 2`

https://cbonte.github.io/haproxy-dconv/2.4/configuration.html#5.2-fall
https://cbonte.github.io/haproxy-dconv/2.4/configuration.html#5.2-rise

This PR will expose these options for backend health checks (anywhere where `backend_use_http_health` is set to true), while setting the default values to match the HAProxy defaults above.