### PR TITLE
Add release notes for 11.8.0

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,2 @@
+# New Features
+- Adds new properties `backend_health_fall` and `backend_health_rise` for backend health checks. These are enabled if `backend_use_http_health` is set to true and correspond to the the `fall` and `rise` parameters in HAProxy


### PR DESCRIPTION
Release notes for 11.8.0 - adding the `backend_health_fall` and `backend_health_rise` options to backend health checks.