### PR TITLE
Additional backend acls

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -332,6 +332,7 @@ properties:
           backend_http_health_uri:  /health # optional, defaults to /health. sets the URI for backend http health checks
           backend_health_fall: 3  # optional, ignored if backend_use_http_health is false. Defaults to 3 if not set. Number of consecutive unsuccessful health checks required before the server is considered unhealthy from a healthy state.
           backend_health_rise: 2  # optional, ignored if backend_use_http_health is false. Defaults to 2 if not set. Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state.
+          additional_acls: ["method GET"] # optional, defaults to []. Include additional ACLs that are required for this backend to be used. ACLs are combined with logical AND
 
   ha_proxy.headers:
     description: "Hash of custom headers you wish you have set on each request. Spaces are automatically escaped, but any other haproxy delimiters will need to be escaped manually"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -389,10 +389,14 @@ frontend http-in
     <%- end -%>
     http-request deny if internal !private
   <%- end -%>
-  <%- p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+  <%- p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
     <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
+    <%- data.fetch("additional_acls", []).each_with_index do |acl, i| -%>
+    acl routed_backend_<%= prefix_hash %>_<%= i %> <%= acl %>
+    <%- end -%>
+    <%- additional_acls = data.fetch("additional_acls", []).count.times.map {|i| "routed_backend_#{prefix_hash}_#{i}"} %>
+    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %> <%= additional_acls.join " " %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     http-request add-header X-Forwarded-Proto "http" if ! xfp_exists
@@ -539,10 +543,14 @@ frontend https-in
     <%- end -%>
     http-request deny if internal !private
   <%- end -%>
-  <%- p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+  <%- p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
     <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
+    <%- data.fetch("additional_acls", []).each_with_index do |acl, i| -%>
+    acl routed_backend_<%= prefix_hash %>_<%= i %> <%= acl %>
+    <%- end -%>
+    <%- additional_acls = data.fetch("additional_acls", []).count.times.map {|i| "routed_backend_#{prefix_hash}_#{i}"} %>
+    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %> <%= additional_acls.join " " %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     http-request add-header X-Forwarded-Proto "https" if ! xfp_exists
@@ -690,10 +698,14 @@ frontend wss-in
     <%- end -%>
     http-request deny if internal !private
   <%- end -%>
-  <%- p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+  <%- p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
     <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
+    <%- data.fetch("additional_acls", []).each_with_index do |acl, i| -%>
+    acl routed_backend_<%= prefix_hash %>_<%= i %> <%= acl %>
+    <%- end -%>
+    <%- additional_acls = data.fetch("additional_acls", []).count.times.map {|i| "routed_backend_#{prefix_hash}_#{i}"} %>
+    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %> <%= additional_acls.join " " %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     http-request add-header X-Forwarded-Proto "https" if ! xfp_exists

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -390,13 +390,15 @@ frontend http-in
     http-request deny if internal !private
   <%- end -%>
   <%- p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
-    <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
-    acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-    <%- data.fetch("additional_acls", []).each_with_index do |acl, i| -%>
-    acl routed_backend_<%= prefix_hash %>_<%= i %> <%= acl %>
+    <%-
+      prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5]
+      acls = ["path_beg #{prefix}"].concat(data.fetch("additional_acls", []))
+      acl_hash = acls.each_with_index.map { |rule, i| ["routed_backend_#{prefix_hash}_#{i}", rule] }.to_h
+    -%>
+    <%- acl_hash.each do |name, rule| %>
+    acl <%= name %> <%= rule %>
     <%- end -%>
-    <%- additional_acls = data.fetch("additional_acls", []).count.times.map {|i| "routed_backend_#{prefix_hash}_#{i}"} %>
-    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %> <%= additional_acls.join " " %>
+    use_backend http-routed-backend-<%= prefix_hash %> if <%= acl_hash.keys.join " " %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     http-request add-header X-Forwarded-Proto "http" if ! xfp_exists
@@ -544,13 +546,15 @@ frontend https-in
     http-request deny if internal !private
   <%- end -%>
   <%- p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
-    <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
-    acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-    <%- data.fetch("additional_acls", []).each_with_index do |acl, i| -%>
-    acl routed_backend_<%= prefix_hash %>_<%= i %> <%= acl %>
+    <%-
+      prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5]
+      acls = ["path_beg #{prefix}"].concat(data.fetch("additional_acls", []))
+      acl_hash = acls.each_with_index.map { |rule, i| ["routed_backend_#{prefix_hash}_#{i}", rule] }.to_h
+    -%>
+    <%- acl_hash.each do |name, rule| %>
+    acl <%= name %> <%= rule %>
     <%- end -%>
-    <%- additional_acls = data.fetch("additional_acls", []).count.times.map {|i| "routed_backend_#{prefix_hash}_#{i}"} %>
-    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %> <%= additional_acls.join " " %>
+    use_backend http-routed-backend-<%= prefix_hash %> if <%= acl_hash.keys.join " " %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     http-request add-header X-Forwarded-Proto "https" if ! xfp_exists
@@ -699,13 +703,15 @@ frontend wss-in
     http-request deny if internal !private
   <%- end -%>
   <%- p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
-    <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
-    acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-    <%- data.fetch("additional_acls", []).each_with_index do |acl, i| -%>
-    acl routed_backend_<%= prefix_hash %>_<%= i %> <%= acl %>
+    <%-
+      prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5]
+      acls = ["path_beg #{prefix}"].concat(data.fetch("additional_acls", []))
+      acl_hash = acls.each_with_index.map { |rule, i| ["routed_backend_#{prefix_hash}_#{i}", rule] }.to_h
+    -%>
+    <%- acl_hash.each do |name, rule| %>
+    acl <%= name %> <%= rule %>
     <%- end -%>
-    <%- additional_acls = data.fetch("additional_acls", []).count.times.map {|i| "routed_backend_#{prefix_hash}_#{i}"} %>
-    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %> <%= additional_acls.join " " %>
+    use_backend http-routed-backend-<%= prefix_hash %> if <%= acl_hash.keys.join " " %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     http-request add-header X-Forwarded-Proto "https" if ! xfp_exists

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -231,6 +231,24 @@ describe 'config/haproxy.config HTTP frontend' do
       expect(frontend_http).to include('acl routed_backend_9c1bb7 path_beg /images')
       expect(frontend_http).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7')
     end
+
+    context 'when a routed_backend_server contains additional_acls' do
+      let(:properties) do
+        super().deep_merge({
+          'routed_backend_servers' => {
+            '/images' => {
+              'additional_acls' => ['method GET', 'path_end /foo']
+            }
+          }
+        })
+      end
+
+      it 'includes additional acls' do
+        expect(frontend_http).to include('acl routed_backend_9c1bb7_0 method GET')
+        expect(frontend_http).to include('acl routed_backend_9c1bb7_1 path_end /foo')
+        expect(frontend_http).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7 routed_backend_9c1bb7_0 routed_backend_9c1bb7_1')
+      end
+    end
   end
 
   it 'adds the X-Forwarded-Proto header' do

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -228,8 +228,8 @@ describe 'config/haproxy.config HTTP frontend' do
     end
 
     it 'grants access to the backend servers' do
-      expect(frontend_http).to include('acl routed_backend_9c1bb7 path_beg /images')
-      expect(frontend_http).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7')
+      expect(frontend_http).to include('acl routed_backend_9c1bb7_0 path_beg /images')
+      expect(frontend_http).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7_0')
     end
 
     context 'when a routed_backend_server contains additional_acls' do
@@ -244,9 +244,9 @@ describe 'config/haproxy.config HTTP frontend' do
       end
 
       it 'includes additional acls' do
-        expect(frontend_http).to include('acl routed_backend_9c1bb7_0 method GET')
-        expect(frontend_http).to include('acl routed_backend_9c1bb7_1 path_end /foo')
-        expect(frontend_http).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7 routed_backend_9c1bb7_0 routed_backend_9c1bb7_1')
+        expect(frontend_http).to include('acl routed_backend_9c1bb7_1 method GET')
+        expect(frontend_http).to include('acl routed_backend_9c1bb7_2 path_end /foo')
+        expect(frontend_http).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7_0 routed_backend_9c1bb7_1 routed_backend_9c1bb7_2')
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -610,6 +610,24 @@ describe 'config/haproxy.config HTTPS frontend' do
       expect(frontend_https).to include('acl routed_backend_9c1bb7 path_beg /images')
       expect(frontend_https).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7')
     end
+
+    context 'when a routed_backend_server contains additional_acls' do
+      let(:properties) do
+        super().deep_merge({
+          'routed_backend_servers' => {
+            '/images' => {
+              'additional_acls' => ['method GET', 'path_end /foo']
+            }
+          }
+        })
+      end
+
+      it 'includes additional acls' do
+        expect(frontend_https).to include('acl routed_backend_9c1bb7_0 method GET')
+        expect(frontend_https).to include('acl routed_backend_9c1bb7_1 path_end /foo')
+        expect(frontend_https).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7 routed_backend_9c1bb7_0 routed_backend_9c1bb7_1')
+      end
+    end
   end
 
   it 'adds the X-Forwarded-Proto header' do

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -607,8 +607,8 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
 
     it 'grants access to the backend servers' do
-      expect(frontend_https).to include('acl routed_backend_9c1bb7 path_beg /images')
-      expect(frontend_https).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7')
+      expect(frontend_https).to include('acl routed_backend_9c1bb7_0 path_beg /images')
+      expect(frontend_https).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7_0')
     end
 
     context 'when a routed_backend_server contains additional_acls' do
@@ -623,9 +623,9 @@ describe 'config/haproxy.config HTTPS frontend' do
       end
 
       it 'includes additional acls' do
-        expect(frontend_https).to include('acl routed_backend_9c1bb7_0 method GET')
-        expect(frontend_https).to include('acl routed_backend_9c1bb7_1 path_end /foo')
-        expect(frontend_https).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7 routed_backend_9c1bb7_0 routed_backend_9c1bb7_1')
+        expect(frontend_https).to include('acl routed_backend_9c1bb7_1 method GET')
+        expect(frontend_https).to include('acl routed_backend_9c1bb7_2 path_end /foo')
+        expect(frontend_https).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7_0 routed_backend_9c1bb7_1 routed_backend_9c1bb7_2')
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -636,6 +636,24 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       expect(frontend_wss).to include('acl routed_backend_9c1bb7 path_beg /images')
       expect(frontend_wss).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7')
     end
+
+    context 'when a routed_backend_server contains additional_acls' do
+      let(:properties) do
+        super().deep_merge({
+          'routed_backend_servers' => {
+            '/images' => {
+              'additional_acls' => ['method GET', 'path_end /foo']
+            }
+          }
+        })
+      end
+
+      it 'includes additional acls' do
+        expect(frontend_wss).to include('acl routed_backend_9c1bb7_0 method GET')
+        expect(frontend_wss).to include('acl routed_backend_9c1bb7_1 path_end /foo')
+        expect(frontend_wss).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7 routed_backend_9c1bb7_0 routed_backend_9c1bb7_1')
+      end
+    end
   end
 
   it 'adds the X-Forwarded-Proto header' do

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -633,8 +633,8 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
 
     it 'grants access to the backend servers' do
-      expect(frontend_wss).to include('acl routed_backend_9c1bb7 path_beg /images')
-      expect(frontend_wss).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7')
+      expect(frontend_wss).to include('acl routed_backend_9c1bb7_0 path_beg /images')
+      expect(frontend_wss).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7_0')
     end
 
     context 'when a routed_backend_server contains additional_acls' do
@@ -649,9 +649,9 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       end
 
       it 'includes additional acls' do
-        expect(frontend_wss).to include('acl routed_backend_9c1bb7_0 method GET')
-        expect(frontend_wss).to include('acl routed_backend_9c1bb7_1 path_end /foo')
-        expect(frontend_wss).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7 routed_backend_9c1bb7_0 routed_backend_9c1bb7_1')
+        expect(frontend_wss).to include('acl routed_backend_9c1bb7_1 method GET')
+        expect(frontend_wss).to include('acl routed_backend_9c1bb7_2 path_end /foo')
+        expect(frontend_wss).to include('use_backend http-routed-backend-9c1bb7 if routed_backend_9c1bb7_0 routed_backend_9c1bb7_1 routed_backend_9c1bb7_2')
       end
     end
   end


### PR DESCRIPTION
For use as a general reverse proxy it is useful to be able to route based on more than just `path_beg`. This should be a no-op change for most users but provide a way to configure additional routing rules for backends through a new `additional_acls` property.

This PR is split into 2 commits as I wasn't sure if adding `_0` to the (default) `path_beg` acl made sense or whether to just leave it without a suffix and start numbering the additional acls only. I think I prefer handling them all the same way personally. The PR can be squashed if this is preferred.