### PR TITLE
Parallelize acceptance tests

### DIFF
--- a/acceptance-tests/access_control_test.go
+++ b/acceptance-tests/access_control_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Access Control", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    12000,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileWhitelist}, map[string]interface{}{
 			"cidr_whitelist": []string{"127.0.0.1/32"},
 		}, true)
@@ -72,7 +72,7 @@ var _ = Describe("Access Control", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    12000,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileBlacklist}, map[string]interface{}{
 			// traffic from test runner appears to come from this CIDR block
 			"cidr_blacklist": []string{"10.0.0.0/8"},

--- a/acceptance-tests/backend_match_http_protocol_test.go
+++ b/acceptance-tests/backend_match_http_protocol_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Backend match HTTP protocol", func() {
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileHTTPS}, map[string]interface{}{}, true)
 
 		err := varsStoreReader(&creds)
@@ -103,7 +103,7 @@ var _ = Describe("Backend match HTTP protocol", func() {
 
 		var localPort int
 		closeLocalServer, localPort, err = startLocalHTTPServer(backendTLSConfig, func(w http.ResponseWriter, r *http.Request) {
-			fmt.Println("Backend server handling incoming request")
+			writeLog("Backend server handling incoming request")
 			protocolHeaderValue := "none"
 			if r.TLS != nil {
 				protocolHeaderValue = r.TLS.NegotiatedProtocol

--- a/acceptance-tests/bosh_helpers.go
+++ b/acceptance-tests/bosh_helpers.go
@@ -52,9 +52,7 @@ var opsfileAddSSHUser string = `---
   path: /releases/-
   value:
     name: os-conf
-    version: "22.1.1"
-    url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.1
-    sha1: "4f653168954749992a541d228dd4f936f2eff2d6"
+    version: latest
 
 # Add an SSH user
 - type: replace
@@ -151,18 +149,18 @@ func deployHAProxy(baseManifestVars baseManifestVars, customOpsfiles []string, c
 }
 
 func dumpCmd(cmd *exec.Cmd) {
-	fmt.Println("---------- Command to run ----------")
-	fmt.Println(cmd.String())
-	fmt.Println("------------------------------------")
+	writeLog("---------- Command to run ----------")
+	writeLog(cmd.String())
+	writeLog("------------------------------------")
 }
 
 func dumpHAProxyConfig(haproxyInfo haproxyInfo) {
 	By("Checking /var/vcap/jobs/haproxy/config/haproxy.config")
 	haProxyConfig, _, err := runOnRemote(haproxyInfo.SSHUser, haproxyInfo.PublicIP, haproxyInfo.SSHPrivateKey, "cat /var/vcap/jobs/haproxy/config/haproxy.config")
 	Expect(err).NotTo(HaveOccurred())
-	fmt.Println("---------- HAProxy Config ----------")
-	fmt.Println(haProxyConfig)
-	fmt.Println("------------------------------------")
+	writeLog("---------- HAProxy Config ----------")
+	writeLog(haProxyConfig)
+	writeLog("------------------------------------")
 }
 
 // Takes bosh deployment name, ops files and vars.
@@ -176,10 +174,10 @@ func deployBaseManifestCmd(boshDeployment string, opsFilesContents []string, var
 		opsFile, err := ioutil.TempFile("", "haproxy-tests-ops-file-*.yml")
 		Expect(err).NotTo(HaveOccurred())
 
-		fmt.Printf("Writing ops file to %s\n", opsFile.Name())
-		fmt.Println("------------------------------------")
-		fmt.Println(opsFileContents)
-		fmt.Println("------------------------------------")
+		writeLog(fmt.Sprintf("Writing ops file to %s\n", opsFile.Name()))
+		writeLog("------------------------------------")
+		writeLog(opsFileContents)
+		writeLog("------------------------------------")
 
 		_, err = opsFile.WriteString(opsFileContents)
 		Expect(err).NotTo(HaveOccurred())
@@ -197,10 +195,10 @@ func deployBaseManifestCmd(boshDeployment string, opsFilesContents []string, var
 		bytes, err := json.Marshal(vars)
 		Expect(err).NotTo(HaveOccurred())
 
-		fmt.Printf("Writing vars file to %s\n", varsFile.Name())
-		fmt.Println("------------------------------------")
-		fmt.Println(string(bytes))
-		fmt.Println("------------------------------------")
+		writeLog(fmt.Sprintf("Writing vars file to %s\n", varsFile.Name()))
+		writeLog("------------------------------------")
+		writeLog(string(bytes))
+		writeLog("------------------------------------")
 
 		_, err = varsFile.Write(bytes)
 		Expect(err).NotTo(HaveOccurred())
@@ -255,7 +253,7 @@ func (instance boshInstance) ParseIPs() []string {
 }
 
 func boshInstances(boshDeployment string) []boshInstance {
-	fmt.Printf("Fetching Bosh instances")
+	writeLog("Fetching Bosh instances")
 	cmd := config.boshCmd(boshDeployment, "--json", "instances", "--details")
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())

--- a/acceptance-tests/buffer_size_test.go
+++ b/acceptance-tests/buffer_size_test.go
@@ -23,7 +23,7 @@ var _ = Describe("max_rewrite and buffer_size_bytes", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileBufferSize}, map[string]interface{}{}, true)
 
 		closeLocalServer, localPort := startDefaultTestServer()

--- a/acceptance-tests/config.go
+++ b/acceptance-tests/config.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 )
 
+var config Config
+
 type Config struct {
 	ReleaseRepoPath  string `json:"releaseRepoPath"`
 	ReleaseVersion   string `json:"releaseVersion"`
@@ -17,8 +19,6 @@ type Config struct {
 	BaseManifestPath string `json:"baseManifestPath"`
 	HomePath         string `json:"homePath"`
 }
-
-var config Config
 
 func loadConfig() (Config, error) {
 	releaseRepoPath, err := getEnvOrFail("REPO_ROOT")

--- a/acceptance-tests/domain_fronting_test.go
+++ b/acceptance-tests/domain_fronting_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Domain fronting", func() {
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfile}, map[string]interface{}{
 			"disable_domain_fronting": disableDomainFronting,
 			"cert_common_name":        "haproxy.internal",

--- a/acceptance-tests/healthcheck_test.go
+++ b/acceptance-tests/healthcheck_test.go
@@ -23,11 +23,11 @@ var _ = Describe("HTTP Health Check", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileHTTPHealthcheck}, map[string]interface{}{}, false)
 
 		// Verify that is in a failing state
-		Expect(boshInstances(defaultDeploymentName)[0].ProcessState).To(Or(Equal("failing"), Equal("unresponsive agent")))
+		Expect(boshInstances(deploymentNameForTestNode())[0].ProcessState).To(Or(Equal("failing"), Equal("unresponsive agent")))
 
 		closeLocalServer, localPort := startDefaultTestServer()
 		defer closeLocalServer()
@@ -40,7 +40,7 @@ var _ = Describe("HTTP Health Check", func() {
 		// and monit should in turn start reporting a healthy process
 		// We will up to wait one minute for the status to stabilise
 		Eventually(func() string {
-			return boshInstances(defaultDeploymentName)[0].ProcessState
+			return boshInstances(deploymentNameForTestNode())[0].ProcessState
 		}, time.Minute, time.Second).Should(Equal("running"))
 
 		By("The healthcheck health endpoint should report a 200 status code")
@@ -71,11 +71,11 @@ var _ = Describe("HTTP Health Check", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    80,
 			haproxyBackendServers: []string{backendHaproxyInfo.PublicIP},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileHTTPHealthcheck}, map[string]interface{}{}, true)
 
 		// Verify that instance is in a running state
-		Expect(boshInstances(defaultDeploymentName)[0].ProcessState).To(Equal("running"))
+		Expect(boshInstances(deploymentNameForTestNode())[0].ProcessState).To(Equal("running"))
 
 		By("The healthcheck health endpoint should report a 200 status code")
 		expect200(http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP)))

--- a/acceptance-tests/http_frontend_test.go
+++ b/acceptance-tests/http_frontend_test.go
@@ -13,7 +13,7 @@ var _ = Describe("HTTP Frontend", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{}, map[string]interface{}{}, true)
 
 		closeLocalServer, localPort := startDefaultTestServer()

--- a/acceptance-tests/https_ext_crt_list_test.go
+++ b/acceptance-tests/https_ext_crt_list_test.go
@@ -98,7 +98,7 @@ var _ = Describe("External Certificate Lists", func() {
 		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileSSLCertificate}, map[string]interface{}{
 			"ext_crt_list_path": extCrtListPath,
 		}, true)
@@ -237,7 +237,7 @@ var _ = Describe("External Certificate Lists", func() {
 				deployHAProxy(baseManifestVars{
 					haproxyBackendPort:    haproxyBackendPort,
 					haproxyBackendServers: []string{"127.0.0.1"},
-					deploymentName:        defaultDeploymentName,
+					deploymentName:        deploymentNameForTestNode(),
 				}, []string{opfileExternalCertificatePolicyFail}, map[string]interface{}{}, true)
 			})
 		})
@@ -289,7 +289,7 @@ var _ = Describe("External Certificate Lists", func() {
 				haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
 					haproxyBackendPort:    haproxyBackendPort,
 					haproxyBackendServers: []string{"127.0.0.1"},
-					deploymentName:        defaultDeploymentName,
+					deploymentName:        deploymentNameForTestNode(),
 				}, []string{opfileExternalCertificatePolicyFail, opsfileOSConfProvidedCertificate, opsfileSSLCertVariable}, map[string]interface{}{}, true)
 
 				// Ensure file written by os-conf is cleaned up for next test
@@ -330,7 +330,7 @@ var _ = Describe("External Certificate Lists", func() {
 					haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
 						haproxyBackendPort:    haproxyBackendPort,
 						haproxyBackendServers: []string{"127.0.0.1"},
-						deploymentName:        defaultDeploymentName,
+						deploymentName:        deploymentNameForTestNode(),
 					}, []string{opfileExternalCertificatePolicyFail, opsfileSSLCertVariable}, map[string]interface{}{}, true)
 
 					var creds struct {
@@ -347,8 +347,9 @@ var _ = Describe("External Certificate Lists", func() {
 					baseManifestVars := baseManifestVars{
 						haproxyBackendPort:    haproxyBackendPort,
 						haproxyBackendServers: []string{"127.0.0.1"},
-						deploymentName:        defaultDeploymentName,
+						deploymentName:        deploymentNameForTestNode(),
 					}
+
 					// Override SSH key and certificate with existing values to avoid re-generating
 					manifestVars := buildManifestVars(baseManifestVars, map[string]interface{}{
 						"ssh_key": map[string]string{
@@ -359,7 +360,7 @@ var _ = Describe("External Certificate Lists", func() {
 						"cert": creds.Cert,
 					})
 					opsfiles := append(defaultOpsfiles, opfileExternalCertificatePolicyFail, opsfileSSLCertVariable)
-					deployCmd, _ := deployBaseManifestCmd(defaultDeploymentName, opsfiles, manifestVars)
+					deployCmd, _ := deployBaseManifestCmd(deploymentNameForTestNode(), opsfiles, manifestVars)
 					// Recreate VM to ensure that HAProxy process is restarted
 					deployCmd.Args = append(deployCmd.Args, "--recreate")
 					buffer := gbytes.NewBuffer()

--- a/acceptance-tests/https_frontend_test.go
+++ b/acceptance-tests/https_frontend_test.go
@@ -96,7 +96,7 @@ var _ = Describe("HTTPS Frontend", func() {
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileHTTPS}, map[string]interface{}{
 			"enable_http2": enableHTTP2,
 		}, true)

--- a/acceptance-tests/keepalived_test.go
+++ b/acceptance-tests/keepalived_test.go
@@ -9,7 +9,7 @@ import (
 
 var _ = Describe("keepalived", func() {
 	It("Deploys haproxy with keepalived", func() {
-		opsfileBufferSize := `---
+		opsfileKeepalived := `---
 - type: replace
   path: /instance_groups/name=haproxy/jobs/name=keepalived?/release?
   value: haproxy
@@ -22,8 +22,8 @@ var _ = Describe("keepalived", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
-		}, []string{opsfileBufferSize}, map[string]interface{}{}, true)
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileKeepalived}, map[string]interface{}{}, true)
 		closeLocalServer, localPort := startDefaultTestServer()
 		defer closeLocalServer()
 

--- a/acceptance-tests/master_cli_test.go
+++ b/acceptance-tests/master_cli_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Master CLI", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    12000,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileMasterCLI}, map[string]interface{}{}, true)
 
 		By("The master CLI 'show proc' command works")

--- a/acceptance-tests/mtls_frontend_test.go
+++ b/acceptance-tests/mtls_frontend_test.go
@@ -113,7 +113,7 @@ var _ = Describe("mTLS", func() {
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileMTLS}, map[string]interface{}{}, true)
 
 		err := varsStoreReader(&creds)

--- a/acceptance-tests/remote.go
+++ b/acceptance-tests/remote.go
@@ -56,7 +56,7 @@ func startSSHPortForwarder(user string, addr string, privateKey string, localPor
 		return err
 	}
 
-	fmt.Printf("Listening on 127.0.0.1:%d on local machine\n", remotePort)
+	writeLog(fmt.Sprintf("Listening on 127.0.0.1:%d on local machine\n", remotePort))
 	localListener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
 	if err != nil {
 		return err
@@ -67,9 +67,9 @@ func startSSHPortForwarder(user string, addr string, privateKey string, localPor
 			localClient, err := localListener.Accept()
 			if err != nil {
 				if err == io.EOF {
-					fmt.Println("Local connection closed")
+					writeLog("Local connection closed")
 				} else {
-					fmt.Printf("Error accepting connection on local listener: %s\n", err.Error())
+					writeLog(fmt.Sprintf("Error accepting connection on local listener: %s\n", err.Error()))
 				}
 
 				return
@@ -77,7 +77,7 @@ func startSSHPortForwarder(user string, addr string, privateKey string, localPor
 
 			remoteConn, err := remoteConn.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", remotePort))
 			if err != nil {
-				fmt.Printf("Error dialing local port %d: %s\n", remotePort, err.Error())
+				writeLog(fmt.Sprintf("Error dialing local port %d: %s\n", remotePort, err.Error()))
 				return
 			}
 
@@ -88,7 +88,7 @@ func startSSHPortForwarder(user string, addr string, privateKey string, localPor
 
 	go func() {
 		<-ctx.Done()
-		fmt.Println("Closing local listener")
+		writeLog("Closing local listener")
 		localListener.Close()
 	}()
 
@@ -103,7 +103,7 @@ func startReverseSSHPortForwarder(user string, addr string, privateKey string, r
 		return err
 	}
 
-	fmt.Printf("Listening on 127.0.0.1:%d on remote machine\n", remotePort)
+	writeLog(fmt.Sprintf("Listening on 127.0.0.1:%d on remote machine\n", remotePort))
 	remoteListener, err := remoteConn.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", remotePort))
 	if err != nil {
 		return err
@@ -114,9 +114,9 @@ func startReverseSSHPortForwarder(user string, addr string, privateKey string, r
 			remoteClient, err := remoteListener.Accept()
 			if err != nil {
 				if err == io.EOF {
-					fmt.Println("Remote connection closed")
+					writeLog("Remote connection closed")
 				} else {
-					fmt.Printf("Error accepting connection on remote listener: %s\n", err.Error())
+					writeLog(fmt.Sprintf("Error accepting connection on remote listener: %s\n", err.Error()))
 				}
 
 				return
@@ -124,7 +124,7 @@ func startReverseSSHPortForwarder(user string, addr string, privateKey string, r
 
 			localConn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
 			if err != nil {
-				fmt.Printf("Error dialing local port %d: %s\n", localPort, err.Error())
+				writeLog(fmt.Sprintf("Error dialing local port %d: %s\n", localPort, err.Error()))
 				return
 			}
 
@@ -135,7 +135,7 @@ func startReverseSSHPortForwarder(user string, addr string, privateKey string, r
 
 	go func() {
 		<-ctx.Done()
-		fmt.Println("Closing remote listener")
+		writeLog("Closing remote listener")
 		remoteListener.Close()
 	}()
 
@@ -188,7 +188,7 @@ func buildSSHClient(user string, addr string, privateKey string) (*ssh.Client, e
 		return nil, err
 	}
 
-	fmt.Printf("Connecting to %s:%d as user %s using private key\n", addr, 22, user)
+	writeLog(fmt.Sprintf("Connecting to %s:%d as user %s using private key\n", addr, 22, user))
 	return ssh.Dial("tcp", net.JoinHostPort(addr, "22"), config)
 }
 

--- a/acceptance-tests/strict_sni_test.go
+++ b/acceptance-tests/strict_sni_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Strict SNI", func() {
 		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfile}, map[string]interface{}{
 			"cert_common_name": "haproxy.internal",
 			"cert_sans":        []string{"haproxy.internal"},

--- a/acceptance-tests/tcp_frontend_test.go
+++ b/acceptance-tests/tcp_frontend_test.go
@@ -25,7 +25,7 @@ var _ = Describe("TCP Frontend", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    12000,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileTCP}, map[string]interface{}{
 			"tcp_frontend_port": tcpFrontendPort,
 			"tcp_backend_port":  tcpBackendPort,

--- a/acceptance-tests/websocket_test.go
+++ b/acceptance-tests/websocket_test.go
@@ -75,7 +75,7 @@ var _ = Describe("HTTPS Frontend", func() {
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileHTTPS}, map[string]interface{}{
 			"enable_http2":                     enableHTTP2,
 			"disable_backend_http2_websockets": disableBackendHttp2Websockets,

--- a/acceptance-tests/xenial_test.go
+++ b/acceptance-tests/xenial_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Xenial", func() {
 		haproxyInfo, _ := deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileXenial}, map[string]interface{}{}, true)
 
 		closeLocalServer, localPort := startDefaultTestServer()

--- a/acceptance-tests/xfcc_test.go
+++ b/acceptance-tests/xfcc_test.go
@@ -141,7 +141,7 @@ var _ = Describe("forwarded_client_cert", func() {
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
+			deploymentName:        deploymentNameForTestNode(),
 		}, []string{opsfileForwardedClientCert}, deployVars, true)
 
 		err = varsStoreReader(&creds)
@@ -150,7 +150,7 @@ var _ = Describe("forwarded_client_cert", func() {
 		By("Starting a local http server to act as a backend")
 		var localPort int
 		closeLocalServer, localPort, err = startLocalHTTPServer(nil, func(w http.ResponseWriter, r *http.Request) {
-			fmt.Println("Backend server handling incoming request")
+			writeLog("Backend server handling incoming request")
 			recordedHeaders = r.Header
 			_, _ = w.Write([]byte("OK"))
 		})

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -41,6 +41,10 @@ bosh -n upload-stemcell $stemcell_xenial_path
 echo "----- Uploading BPM"
 bosh -n upload-release $bpm_release_path
 
+echo "----- Uploading os-conf (used for tests only)"
+bosh -n upload-release --sha1 386293038ae3d00813eaa475b4acf63f8da226ef \
+  https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.2
+
 export BOSH_PATH=$(which bosh)
 export BASE_MANIFEST_PATH="$PWD/manifests/haproxy.yml"
 
@@ -52,4 +56,4 @@ go mod download
 echo "----- Running tests"
 
 export PATH=$PATH:$GOPATH/bin
-ginkgo -v -r -debug -trace -progress -randomizeAllSpecs
+ginkgo -v -p -r -debug -trace -progress -randomizeAllSpecs


### PR DESCRIPTION
The acceptance tests currently take around 50 minutes to run.

The first 10 minutes of this is deploying the BOSH director using BOSH lite. This can't be easily parallelized.

The next 40 minutes is the tests themselves where we deploy HAProxy to the BOSH lite director in different configurations. This PR parallelizes this process via the `ginkgo -p` [flag](https://onsi.github.io/ginkgo/#parallel-specs) which by default uses one thread per CPU when run on a machine with four or fewer CPUs, or CPUs - 1 when run on a machine with more than four CPUs. It uses seven threads on our Concourse CI server. Note that the HAProxy deployments now need unique names per thread (although deployments in the same thread can reuse the deployment name).

This change reduces the test execution time from 40 minutes to about 20 minutes, so total time is approximately 30 minutes including the initial BOSH director setup.

Note that when deploying a new deployment the bosh director will compile any releases that haven't been compiled before with the required stemcells. To avoid all threads in the parallelized tests running the same compilations at the same time, this PR deploys HAProxy once in a `SynchronizedBeforeSuite` block which runs before any tests. This ensures that the first deployment in each of the test threads can make used of already-compiled releases.
