### PR TITLE
Add SHA-256 for the Release page

### DIFF
--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -68,6 +68,8 @@ bosh -n create-release releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.yml \
 cd -
 
 RELEASE_TGZ=$REPO_ROOT/releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.tgz
+export SHA1=$(sha1sum $RELEASE_TGZ | head -n1 | awk '{print $1}')
+echo "SHA1=$SHA1"
 export SHA256=$(sha256sum $RELEASE_TGZ | head -n1 | awk '{print $1}')
 echo "SHA256=$SHA256"
 
@@ -84,7 +86,10 @@ releases:
 - name: "$RELEASE_NAME"
   version: "$VERSION"
   url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz"
-  sha256: "sha256:$SHA256"
+  sha1: "$SHA1"
+
+# for deployments with sha256, use the following line instead:
+# sha1: "sha256:$SHA256"
 \`\`\`
 EOF
 cat > ${RELEASE_ROOT}/notification <<EOF
@@ -102,7 +107,7 @@ fi
 
 pushd ${REPO_ROOT}
   for MANIFEST_PATH in $(ls manifests/*.yml); do
-    $DIR/update-manifest "$GITHUB_OWNER" "$RELEASE_NAME" "$VERSION" "$SHA256" "$MANIFEST_PATH"
+    $DIR/update-manifest $GITHUB_OWNER $RELEASE_NAME $VERSION $SHA1 $MANIFEST_PATH
   done
   git merge --no-edit ${BRANCH}
   git add -A

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -68,10 +68,10 @@ bosh -n create-release releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.yml \
 cd -
 
 RELEASE_TGZ=$REPO_ROOT/releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.tgz
-export SHA1=$(sha1sum $RELEASE_TGZ | head -n1 | awk '{print $1}')
-echo "SHA1=$SHA1"
+export SHA256=$(sha256sum $RELEASE_TGZ | head -n1 | awk '{print $1}')
+echo "SHA256=$SHA256"
 
-mkdir -p ${RELEASE_ROOT}/artifacts
+mkdir -p "${RELEASE_ROOT}/artifacts"
 echo "v${VERSION}"                         > ${RELEASE_ROOT}/tag
 echo "v${VERSION}"                         > ${RELEASE_ROOT}/name
 mv ${REPO_ROOT}/releases/*/*-${VERSION}.tgz  ${RELEASE_ROOT}/artifacts
@@ -81,10 +81,10 @@ cat >> ${RELEASE_ROOT}/notes.md <<EOF
 ### Deployment
 \`\`\`yaml
 releases:
-- name: $RELEASE_NAME
-  version: $VERSION
-  url: https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz
-  sha1: $SHA1
+- name: "$RELEASE_NAME"
+  version: "$VERSION"
+  url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz"
+  sha256: "sha256:$SHA256"
 \`\`\`
 EOF
 cat > ${RELEASE_ROOT}/notification <<EOF
@@ -102,7 +102,7 @@ fi
 
 pushd ${REPO_ROOT}
   for MANIFEST_PATH in $(ls manifests/*.yml); do
-    $DIR/update-manifest $GITHUB_OWNER $RELEASE_NAME $VERSION $SHA1 $MANIFEST_PATH
+    $DIR/update-manifest "$GITHUB_OWNER" "$RELEASE_NAME" "$VERSION" "$SHA256" "$MANIFEST_PATH"
   done
   git merge --no-edit ${BRANCH}
   git add -A

--- a/ci/scripts/update-manifest
+++ b/ci/scripts/update-manifest
@@ -3,9 +3,9 @@
 GITHUB_OWNER=$1
 RELEASE_NAME=$2
 VERSION=$3
-SHA1=$4
+SHA256=$4
 MANIFEST_PATH=$5
-: ${MANIFEST_PATH:?USAGE: ./ci/scripts/update-manifest GITHUB_OWNER RELEASE_NAME VERSION SHA1 MANIFEST_PATH}
+: ${MANIFEST_PATH:?USAGE: ./ci/scripts/update-manifest GITHUB_OWNER RELEASE_NAME VERSION SHA256 MANIFEST_PATH}
 
 set -e -u
 
@@ -13,8 +13,8 @@ manifest_len=$(wc -l $MANIFEST_PATH | awk '{print $1}')
 manifest_head=$(head -n `expr $manifest_len - 4` $MANIFEST_PATH)
 cat > $MANIFEST_PATH <<YAML
 ${manifest_head}
-- name: $RELEASE_NAME
-  version: $VERSION
-  url: https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz
-  sha1: $SHA1
+- name: "$RELEASE_NAME"
+  version: "$VERSION"
+  url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz"
+  sha1: "sha256:$SHA256"
 YAML

--- a/ci/scripts/update-manifest
+++ b/ci/scripts/update-manifest
@@ -3,9 +3,9 @@
 GITHUB_OWNER=$1
 RELEASE_NAME=$2
 VERSION=$3
-SHA256=$4
+SHA1=$4
 MANIFEST_PATH=$5
-: ${MANIFEST_PATH:?USAGE: ./ci/scripts/update-manifest GITHUB_OWNER RELEASE_NAME VERSION SHA256 MANIFEST_PATH}
+: ${MANIFEST_PATH:?USAGE: ./ci/scripts/update-manifest GITHUB_OWNER RELEASE_NAME VERSION SHA1 MANIFEST_PATH}
 
 set -e -u
 
@@ -13,8 +13,8 @@ manifest_len=$(wc -l $MANIFEST_PATH | awk '{print $1}')
 manifest_head=$(head -n `expr $manifest_len - 4` $MANIFEST_PATH)
 cat > $MANIFEST_PATH <<YAML
 ${manifest_head}
-- name: "$RELEASE_NAME"
-  version: "$VERSION"
-  url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz"
-  sha1: "sha256:$SHA256"
+- name: $RELEASE_NAME
+  version: $VERSION
+  url: https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz
+  sha1: $SHA1
 YAML


### PR DESCRIPTION
Replaces the SHA1 key for releases on the release page with the SHA256 hash.