### PR TITLE
Update HAProxy version to 2.5.4

### DIFF
--- a/acceptance-tests/strict_sni_test.go
+++ b/acceptance-tests/strict_sni_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Strict SNI", func() {
 
 			By("Sending a request to HAProxy with an incorrect SNI is forbidden")
 			_, err = httpClientWrongSNI.Get("https://haproxy.internal")
-			expectTLSHandshakeFailureErr(err)
+			expectTLSUnrecognizedNameErr(err)
 		})
 	})
 })

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,7 @@
+# Upgrades
+
+- `haproxy` has been upgraded to v2.5.4 from v2.4.4
+
+# Acknowledgements
+
+Thanks Alexander Nicke for the Contributions!

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,6 @@
 haproxy/haproxy-2.5.4.tar.gz:
   size: 3819082
+  object_id: 8b4e411e-1726-45ba-4d57-8f2a23df8d58
   sha: sha256:dc4015d85c7fef811b459803b763001d809b07a9251dc1864fedb9a07b44aefb
 haproxy/hatop:
   size: 72445

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,6 +1,6 @@
-haproxy/haproxy-2.5.1.tar.gz:
-  size: 3811260
-  sha: sha256:3e90790dfc832afa6ca4fdf4528de2ce2e74f3e1f74bed0d70ad54bd5920e954
+haproxy/haproxy-2.5.4.tar.gz:
+  size: 3819082
+  sha: sha256:dc4015d85c7fef811b459803b763001d809b07a9251dc1864fedb9a07b44aefb
 haproxy/hatop:
   size: 72445
   object_id: 17a5f66c-bbc1-4e4d-681c-e36420d3e0f5

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,6 @@
-haproxy/haproxy-2.4.4.tar.gz:
-  size: 3587306
-  object_id: 5ff07959-cb68-4de2-59c1-d9886ca1d8a6
-  sha: sha256:116b7329cebee5dab8ba47ad70feeabd0c91680d9ef68c28e41c34869920d1fe
+haproxy/haproxy-2.5.1.tar.gz:
+  size: 3811260
+  sha: sha256:3e90790dfc832afa6ca4fdf4528de2ce2e74f3e1f74bed0d70ad54bd5920e954
 haproxy/hatop:
   size: 72445
   object_id: 17a5f66c-bbc1-4e4d-681c-e36420d3e0f5

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -222,6 +222,9 @@ end
 global
     log <%= p('ha_proxy.syslog_server') %> len <%= p('ha_proxy.log_max_length') %> format <%= p('ha_proxy.log_format') %> syslog <%= p('ha_proxy.log_level') %>
     daemon
+  <%- if p("ha_proxy.drain_enable") -%>
+    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f * 1000).to_i %>
+  <%- end -%>
   <%- if properties.ha_proxy.global_config -%>
     <%= p("ha_proxy.global_config") %>
   <%- end -%>
@@ -322,6 +325,9 @@ listen health_check_http_url
     monitor-uri /health
     acl http-routers_down nbsrv(<%= backends.first[:name] %>) eq 0
     monitor fail if http-routers_down
+    <% if p("ha_proxy.drain_enable") -%>
+    monitor fail if { stopping }
+    <% end -%>
 <% end -%>
 
 <% if_p("ha_proxy.resolvers") do |resolvers| -%>
@@ -338,9 +344,6 @@ resolvers default
 # HTTP Frontend {{{
 frontend http-in
     mode http
-  <% if p("ha_proxy.drain_enable") -%>
-    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
-  <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %> <%= v4v6 %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
@@ -425,9 +428,6 @@ frontend http-in
 # HTTPS Frontend {{{
 frontend https-in
     mode http
-  <% if p("ha_proxy.drain_enable") -%>
-    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
-  <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %> <%= default_alpn_config %>
   <%- if disable_domain_fronting -%>
     # Check whether the client is attempting domain fronting.
@@ -582,9 +582,6 @@ frontend https-in
 # HTTPS Websockets Frontend {{{
 frontend wss-in
     mode http
-  <% if p("ha_proxy.drain_enable") -%>
-    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
-  <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
   <%- if disable_domain_fronting -%>
     # Check whether the client is attempting domain fronting.
@@ -830,9 +827,6 @@ frontend cf_tcp_routing
     mode tcp
     bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %> <%= v4v6 %>
     default_backend cf_tcp_routers
-  <% if p("ha_proxy.drain_enable") -%>
-    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
-  <%- end -%>
 
 backend cf_tcp_routers
     mode tcp
@@ -867,9 +861,6 @@ frontend tcp-frontend_<%= tcp_proxy["name"]%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= v4v6 %>
   <%- end -%>
     default_backend tcp-<%= tcp_proxy["name"] %>
-  <% if p("ha_proxy.drain_enable") -%>
-    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
-  <%- end -%>
 
 backend tcp-<%= tcp_proxy["name"] %>
     mode tcp

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -10,8 +10,8 @@ PCRE_VERSION=10.37
 # http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
 SOCAT_VERSION=1.7.4.1
 
-# http://www.haproxy.org/download/2.4/src/haproxy-2.5.1.tar.gz
-HAPROXY_VERSION=2.5.1
+# http://www.haproxy.org/download/2.4/src/haproxy-2.5.4.tar.gz
+HAPROXY_VERSION=2.5.4
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -10,7 +10,7 @@ PCRE_VERSION=10.37
 # http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
 SOCAT_VERSION=1.7.4.1
 
-# http://www.haproxy.org/download/2.4/src/haproxy-2.5.4.tar.gz
+# http://www.haproxy.org/download/2.5/src/haproxy-2.5.4.tar.gz
 HAPROXY_VERSION=2.5.4
 
 mkdir ${BOSH_INSTALL_TARGET}/bin

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -10,8 +10,8 @@ PCRE_VERSION=10.37
 # http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
 SOCAT_VERSION=1.7.4.1
 
-# http://www.haproxy.org/download/2.4/src/haproxy-2.4.4.tar.gz
-HAPROXY_VERSION=2.4.4
+# http://www.haproxy.org/download/2.4/src/haproxy-2.5.1.tar.gz
+HAPROXY_VERSION=2.5.1
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 

--- a/spec/haproxy/templates/haproxy_config/frontend_cf_tcp_routing_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_cf_tcp_routing_spec.rb
@@ -57,46 +57,6 @@ describe 'config/haproxy.config frontend cf_tcp_routing' do
     expect(frontend_cf_tcp_routing).to include('default_backend cf_tcp_routers')
   end
 
-  context 'when ha_proxy.drain_enable is true' do
-    let(:properties) do
-      {
-        'drain_enable' => true
-      }
-    end
-
-    it 'has a default grace period of 0 milliseconds' do
-      expect(frontend_cf_tcp_routing).to include('grace 0')
-    end
-
-    context('when ha_proxy.drain_frontend_grace_time is provided') do
-      let(:properties) do
-        {
-          'drain_enable' => true,
-          'drain_frontend_grace_time' => 12
-        }
-      end
-
-      it 'overrides the grace period' do
-        expect(frontend_cf_tcp_routing).to include('grace 12000')
-      end
-
-      context 'when ha_proxy.drain_enable is false' do
-        let(:properties) do
-          {
-            'drain_enable' => false,
-            'drain_frontend_grace_time' => 12
-          }
-        end
-
-        it 'aborts with a meaningful error message' do
-          expect do
-            frontend_cf_tcp_routing
-          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
-        end
-      end
-    end
-  end
-
   context 'when no tcp_router link is provided' do
     let(:haproxy_conf) do
       parse_haproxy_config(template.render(properties))

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -10,38 +10,6 @@ describe 'config/haproxy.config HTTP frontend' do
   let(:frontend_http) { haproxy_conf['frontend http-in'] }
   let(:properties) { {} }
 
-  context 'when ha_proxy.drain_enable is true' do
-    let(:properties) do
-      { 'drain_enable' => true }
-    end
-
-    it 'has a default grace period of 0 milliseconds' do
-      expect(frontend_http).to include('grace 0')
-    end
-
-    context('when ha_proxy.drain_frontend_grace_time is provided') do
-      let(:properties) do
-        { 'drain_enable' => true, 'drain_frontend_grace_time' => 12 }
-      end
-
-      it 'overrides the grace period' do
-        expect(frontend_http).to include('grace 12000')
-      end
-
-      context 'when ha_proxy.drain_enable is false' do
-        let(:properties) do
-          { 'drain_enable' => false, 'drain_frontend_grace_time' => 12 }
-        end
-
-        it 'aborts with a meaningful error message' do
-          expect do
-            frontend_http
-          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
-        end
-      end
-    end
-  end
-
   it 'binds to all interfaces by default' do
     expect(frontend_http).to include('bind :80')
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -16,38 +16,6 @@ describe 'config/haproxy.config HTTPS frontend' do
 
   let(:properties) { default_properties }
 
-  context 'when ha_proxy.drain_enable is true' do
-    let(:properties) do
-      default_properties.merge({ 'drain_enable' => true })
-    end
-
-    it 'has a default grace period of 0 milliseconds' do
-      expect(frontend_https).to include('grace 0')
-    end
-
-    context('when ha_proxy.drain_frontend_grace_time is provided') do
-      let(:properties) do
-        default_properties.merge({ 'drain_enable' => true, 'drain_frontend_grace_time' => 12 })
-      end
-
-      it 'overrides the grace period' do
-        expect(frontend_https).to include('grace 12000')
-      end
-
-      context 'when ha_proxy.drain_enable is false' do
-        let(:properties) do
-          default_properties.merge({ 'drain_enable' => false, 'drain_frontend_grace_time' => 12 })
-        end
-
-        it 'aborts with a meaningful error message' do
-          expect do
-            frontend_https
-          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
-        end
-      end
-    end
-  end
-
   it 'binds to all interfaces by default' do
     expect(frontend_https).to include('bind :443  ssl crt /var/vcap/jobs/haproxy/config/ssl')
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_tcp_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_tcp_spec.rb
@@ -47,42 +47,6 @@ describe 'config/haproxy.config custom TCP frontends' do
     expect(frontend_tcp_postgres_via_link).to include('default_backend tcp-postgres')
   end
 
-  context 'when ha_proxy.drain_enable is true' do
-    let(:properties) do
-      default_properties.merge({ 'drain_enable' => true })
-    end
-
-    it 'has a default grace period of 0 milliseconds' do
-      expect(frontend_tcp_redis).to include('grace 0')
-      expect(frontend_tcp_mysql).to include('grace 0')
-      expect(frontend_tcp_postgres_via_link).to include('grace 0')
-    end
-
-    context('when ha_proxy.drain_frontend_grace_time is provided') do
-      let(:properties) do
-        default_properties.merge({ 'drain_enable' => true, 'drain_frontend_grace_time' => 12 })
-      end
-
-      it 'overrides the grace period' do
-        expect(frontend_tcp_redis).to include('grace 12000')
-        expect(frontend_tcp_mysql).to include('grace 12000')
-        expect(frontend_tcp_postgres_via_link).to include('grace 12000')
-      end
-
-      context 'when ha_proxy.drain_enable is false' do
-        let(:properties) do
-          default_properties.merge({ 'drain_enable' => false, 'drain_frontend_grace_time' => 12 })
-        end
-
-        it 'aborts with a meaningful error message' do
-          expect do
-            frontend_tcp_redis
-          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
-        end
-      end
-    end
-  end
-
   it 'binds to all interfaces by default' do
     expect(frontend_tcp_redis).to include('bind :6379')
     expect(frontend_tcp_mysql).to include('bind :3306')

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -18,38 +18,6 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
 
   let(:properties) { default_properties }
 
-  context 'when ha_proxy.drain_enable is true' do
-    let(:properties) do
-      default_properties.merge({ 'drain_enable' => true })
-    end
-
-    it 'has a default grace period of 0 milliseconds' do
-      expect(frontend_wss).to include('grace 0')
-    end
-
-    context('when ha_proxy.drain_frontend_grace_time is provided') do
-      let(:properties) do
-        default_properties.merge({ 'drain_enable' => true, 'drain_frontend_grace_time' => 12 })
-      end
-
-      it 'overrides the grace period' do
-        expect(frontend_wss).to include('grace 12000')
-      end
-
-      context 'when ha_proxy.drain_enable is false' do
-        let(:properties) do
-          default_properties.merge({ 'drain_enable' => false, 'drain_frontend_grace_time' => 12 })
-        end
-
-        it 'aborts with a meaningful error message' do
-          expect do
-            frontend_wss
-          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
-        end
-      end
-    end
-  end
-
   it 'binds to all interfaces by default' do
     expect(frontend_wss).to include('bind :4443  ssl crt /var/vcap/jobs/haproxy/config/ssl')
   end

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -346,6 +346,46 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
+  context 'when ha_proxy.drain_enable is true' do
+    let(:properties) do
+      {
+        'drain_enable' => true
+      }
+    end
+
+    it 'has a default grace period of 0 milliseconds' do
+      expect(global).to include('grace 0')
+    end
+
+    context('when ha_proxy.drain_frontend_grace_time is provided') do
+      let(:properties) do
+        {
+          'drain_enable' => true,
+          'drain_frontend_grace_time' => 12
+        }
+      end
+
+      it 'overrides the default grace period' do
+        expect(global).to include('grace 12000')
+      end
+
+      context 'when ha_proxy.drain_enable is false' do
+        let(:properties) do
+          {
+            'drain_enable' => false,
+            'drain_frontend_grace_time' => 12
+          }
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect { global }.to raise_error(/Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/)
+        end
+      end
+
+
+    end
+  end
+
   context 'when ha_proxy.connect_timeout is provided' do
     let(:properties) do
       {

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -381,8 +381,6 @@ describe 'config/haproxy.config global and default options' do
           expect { global }.to raise_error(/Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/)
         end
       end
-
-
     end
   end
 

--- a/spec/haproxy/templates/haproxy_config/healthcheck_listener_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/healthcheck_listener_spec.rb
@@ -22,6 +22,20 @@ describe 'config/haproxy.config healthcheck listeners' do
       expect(healthcheck_listener).to include('monitor-uri /health')
       expect(healthcheck_listener).to include('acl http-routers_down nbsrv(http-routers-http1) eq 0')
       expect(healthcheck_listener).to include('monitor fail if http-routers_down')
+      expect(healthcheck_listener).not_to include('monitor fail if { stopping }')
+    end
+
+    context 'when ha_proxy.drain_enable is true' do
+      let(:properties) do
+        {
+          'enable_health_check_http' => true,
+          'drain_enable' => true
+        }
+      end
+
+      it 'includes monitor fail if { stopping }' do
+        expect(healthcheck_listener).to include('monitor fail if { stopping }')
+      end
     end
 
     context 'when only http2 backend servers are available' do


### PR DESCRIPTION
The upgrade required changing how the 'grace' keyword is used within the haproxy config. Previously it was added to each indvidual frontend, now it must be enabled as a global option. See the blow documentation from HAProxy for details.

https://www.haproxy.com/blog/announcing-haproxy-2-5/#graceful-stop-of-all-proxies
https://cbonte.github.io/haproxy-dconv/2.5/configuration.html#grace