### PR TITLE
[CVE-2021-44225] Bump keepalived to 2.2.7 from 2.2.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,7 +18,7 @@ haproxy/socat-1.7.4.1.tar.gz:
   size: 648888
   object_id: f6492c7c-ccf1-4997-5e4b-10f97c0b1278
   sha: sha256:0c7e635070af1b9037fd96869fc45eacf9845cb54547681de9d885044538736d
-keepalived/keepalived-2.2.2.tar.gz:
-  size: 1159896
-  object_id: e1cf2ca1-b248-4119-7dda-925e4271588f
-  sha: sha256:103692bd5345a4ed9f4581632ea636214fdf53e45682e200aab122c4fa674ece
+keepalived/keepalived-2.2.7.tar.gz:
+  size: 1180180
+  object_id: 1045d407-50f8-4580-57de-3ef787a88b28
+  sha: sha256:c61940d874154a560a54627ecf7ef47adebdf832164368d10bf242a4d9b7d49d

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -5,9 +5,9 @@ set -e -x
 mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
-#Source can be downloaded at : http://www.keepalived.org/software/keepalived-2.2.2.tar.gz
-tar xzvf keepalived/keepalived-2.2.2.tar.gz
-cd keepalived-2.2.2/
+#Source can be downloaded at : http://www.keepalived.org/software/keepalived-2.2.7.tar.gz
+tar xzvf keepalived/keepalived-2.2.7.tar.gz
+cd keepalived-2.2.7/
 
 #compile keepalive
 ./configure --prefix=${BOSH_INSTALL_TARGET}

--- a/packages/keepalived/spec
+++ b/packages/keepalived/spec
@@ -5,5 +5,5 @@ dependencies: []
 
 files:
 - common/utils.sh
-- keepalived/keepalived-2.2.2.tar.gz
+- keepalived/keepalived-2.2.7.tar.gz
 


### PR DESCRIPTION
This bumps the version of keepalived as version 2.2.2 has a vulnerability as noted in the below link.
[CVE-2021-44225](https://nvd.nist.gov/vuln/detail/CVE-2021-44225)