### PR TITLE
Add release notes

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Upgrades
+
+- `keepalived` has been upgraded to v2.2.7 from v2.2.2


### PR DESCRIPTION
This is the release notes that bumps the keepalived version to 2.2.7 from 2.2.2.