### PR TITLE
Resolve the null bytes in log file after rotation

### DIFF
--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -84,12 +84,14 @@ trap reload_daemon USR2
 
 <%-
   flags=[]
+  cat_pipe=''
 
   # Enable background mode only if syslog is not configured to output to stdout/stderr
   run_in_foreground = p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr"
 
   if run_in_foreground
     flags += ['-V', '-db']
+    cat_pipe='| cat -'
   else
     flags += ['-D']
   end
@@ -101,7 +103,7 @@ trap reload_daemon USR2
 
 # Start up
 echo "$(date): Starting HAProxy"
-haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> | cat -
+haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
 
 <%- if !run_in_foreground -%>
 # Since HAProxy requires Daemonized mode for its `nbproc` multi-process feature

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -101,7 +101,7 @@ trap reload_daemon USR2
 
 # Start up
 echo "$(date): Starting HAProxy"
-haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %>
+haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> | cat -
 
 <%- if !run_in_foreground -%>
 # Since HAProxy requires Daemonized mode for its `nbproc` multi-process feature


### PR DESCRIPTION
When logs are rotated with logrotate using copytruncate haproxy does not
reset the offset and keeps writing from the old offset prepending logs
with null bytes. This results in HAProxy logs growing indefinetely.

Redirect output to pipe and let cat write to log file.

#284 