### PR TITLE
Wait for the main HAProxy process in daemon mode

### DIFF
--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -105,6 +105,7 @@ haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %>
 
 <%- if !run_in_foreground -%>
 # Since HAProxy requires Daemonized mode for its `nbproc` multi-process feature
-# to work properly, and BPM requires the process to stay running, sleep infinitely here
-sleep infinity
+# to work properly, and BPM requires the process to stay running, wait for the 
+# HAProxy main process to terminate
+while kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;
 <%- end -%>


### PR DESCRIPTION
This waits for the main HAProxy process' PID instead of waiting indefinitely.
When the main process goes down, HAProxy will be restarted automatically by BPM.