### PR TITLE
(patched only) Disable HTTP/1.0 check for body in GET/OPTION/DELETE

### DIFF
--- a/haproxy-patches/disable-http10-body-in-get-request.patch
+++ b/haproxy-patches/disable-http10-body-in-get-request.patch
@@ -1,0 +1,27 @@
+--- src/mux_h1.c	2022-02-25 17:10:16.000000000 +0100
++++ src/mux_h1.updated.c	2022-05-05 13:30:41.000000000 +0200
+@@ -1426,24 +1426,6 @@
+ 		goto end;
+ 	}
+
+-
+-	/* Reject HTTP/1.0 GET/HEAD/DELETE requests with a payload. There is a
+-	 * payload if the c-l is not null or the the payload is chunk-encoded.
+-	 * A parsing error is reported but a A 413-Payload-Too-Large is returned
+-	 * instead of a 400-Bad-Request.
+-	 */
+-	if (!(h1m->flags & (H1_MF_RESP|H1_MF_VER_11)) &&
+-	    (((h1m->flags & H1_MF_CLEN) && h1m->body_len) || (h1m->flags & H1_MF_CHNK)) &&
+-	    (h1sl.rq.meth == HTTP_METH_GET || h1sl.rq.meth == HTTP_METH_HEAD || h1sl.rq.meth == HTTP_METH_DELETE)) {
+-		h1s->flags |= H1S_F_PARSING_ERROR;
+-		htx->flags |= HTX_FL_PARSING_ERROR;
+-		h1s->h1c->errcode = 413;
+-		TRACE_ERROR("HTTP/1.0 GET/HEAD/DELETE request with a payload forbidden", H1_EV_RX_DATA|H1_EV_RX_HDRS|H1_EV_H1S_ERR, h1s->h1c->conn, h1s);
+-		h1_capture_bad_message(h1s->h1c, h1s, h1m, buf);
+-		ret = 0;
+-		goto end;
+-	}
+-
+ 	/* Reject any message with an unknown transfer-encoding. In fact if any
+ 	 * encoding other than "chunked". A 422-Unprocessable-Content is
+ 	 * returned for an invalid request, a 502-Bad-Gateway for an invalid


### PR DESCRIPTION
for backwards compatibility.