### PR TITLE
Add upstream version numbers for contained components in release information

### DIFF
--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -80,21 +80,24 @@ mv ${REPO_ROOT}/releases/*/*-${VERSION}.tgz  ${RELEASE_ROOT}/artifacts
 mv ${REPO_ROOT}/ci/release_notes.md          ${RELEASE_ROOT}/notes.md
 
 HAPROXY_VERSION=$(sed -n 's/HAPROXY_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
-SOCAT_VERSION=$(sed -n 's/SOCAT_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
 LUA_VERSION=$(sed -n 's/LUA_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
+SOCAT_VERSION=$(sed -n 's/SOCAT_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
 PCRE_VERSION=$(sed -n 's/PCRE_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
+
+KEEPALIVED_VERSION=$(sed -n 's/KEEPALIVED_VERSION=//p' "${REPO_ROOT}/packages/keepalived/packaging")
 
 cat >> ${RELEASE_ROOT}/notes.md <<EOF
 ### Versions
 
 The following versions of upstream components are included in this haproxy-boshrelease:
 
-| Component | Version |
-| ----------| ------- |
-| HAProxy   | \`${HAPROXY_VERSION}\` |
-| PCRE      | \`${PCRE_VERSION}\` |
-| Lua       | \`${LUA_VERSION}\` |
-| socat     | \`${SOCAT_VERSION}\` |
+| Component   | Version |
+| ----------- | ------- |
+| HAProxy     | \`${HAPROXY_VERSION}\` |
+| keepalived  | \`${KEEPALIVED_VERSION}\` |
+| Lua         | \`${LUA_VERSION}\` |
+| PCRE        | \`${PCRE_VERSION}\` |
+| socat       | \`${SOCAT_VERSION}\` |
 
 ### Deployment
 \`\`\`yaml

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -78,7 +78,23 @@ echo "v${VERSION}"                         > ${RELEASE_ROOT}/tag
 echo "v${VERSION}"                         > ${RELEASE_ROOT}/name
 mv ${REPO_ROOT}/releases/*/*-${VERSION}.tgz  ${RELEASE_ROOT}/artifacts
 mv ${REPO_ROOT}/ci/release_notes.md          ${RELEASE_ROOT}/notes.md
+
+HAPROXY_VERSION=$(sed -n 's/HAPROXY_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
+SOCAT_VERSION=$(sed -n 's/SOCAT_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
+LUA_VERSION=$(sed -n 's/LUA_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
+PCRE_VERSION=$(sed -n 's/PCRE_VERSION=//p' "${REPO_ROOT}/packages/haproxy/packaging")
+
 cat >> ${RELEASE_ROOT}/notes.md <<EOF
+### Versions
+
+The following versions of upstream components are included in this haproxy-boshrelease:
+
+| Component | Version |
+| ----------| ------- |
+| HAProxy   | \`${HAPROXY_VERSION}\` |
+| PCRE      | \`${PCRE_VERSION}\` |
+| Lua       | \`${LUA_VERSION}\` |
+| socat     | \`${SOCAT_VERSION}\` |
 
 ### Deployment
 \`\`\`yaml

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -5,13 +5,12 @@ set -e -x
 mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
-#Source can be downloaded at : http://www.keepalived.org/software/keepalived-2.2.7.tar.gz
-tar xzvf keepalived/keepalived-2.2.7.tar.gz
-cd keepalived-2.2.7/
+KEEPALIVED_VERSION=2.2.7
+#Source can be downloaded at : http://www.keepalived.org/software/keepalived-${KEEPALIVED_VERSION}.tar.gz
+tar xzvf keepalived/keepalived-${KEEPALIVED_VERSION}.tar.gz
+cd keepalived-${KEEPALIVED_VERSION}/
 
 #compile keepalive
 ./configure --prefix=${BOSH_INSTALL_TARGET}
 make 
 make install
-
-


### PR DESCRIPTION
The upstream release version (e.g. HAProxy) contained in an `haproxy-boshrelease` are not evident from its version number.

This change introduces a table of version numbers contained in a particular boshrelease. The version numbers are automatically taken from `packages/*/packaging` and should be representative.