### PR TITLE
allow to define resolvers for backend tcp-routers

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -822,7 +822,12 @@ backend http-routed-backend-<%= prefix_hash %>
 
 # TCP Routing  {{{
 <% if_link("tcp_router") do |tcp_router| -%>
-
+  <%-
+  resolvers = ""
+  if_p("ha_proxy.resolvers") do
+    resolvers = "resolvers default "
+  end 
+  -%>
 frontend cf_tcp_routing
     mode tcp
     bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %> <%= v4v6 %>
@@ -835,7 +840,7 @@ backend cf_tcp_routers
   <%- end -%>
     option httpchk GET /health
   <% tcp_router.instances.each_with_index do |instance, index| %>
-    server node<%= index %> <%= instance.address %> check port 80 inter 1000
+    server node<%= index %> <%= instance.address %> <%= resolvers -%>check port 80 inter 1000
   <% end %>
 <% end -%>
 


### PR DESCRIPTION
This change allows to define resolvers for backend tcp-routers.

Currently, haproxy will fail to start when deploying a fresh cf deployment:
- the haproxy instance is the first VM to be configured in the [cf instance groups](https://github.com/cloudfoundry/cf-deployment/blob/eee6d1918f13f8124ec257f6439d42a110e32d27/operations/use-haproxy.yml#L14-L21)
- server nodes are declared using bosh links which resolve to bosh dns instead of ips (eg. `a63559aa-6052-483a-baa8-33837fa5b928.tcp-router.default.cf.bosh:443`)
- when starting for the first time:
  - those vms are not yet installed by bosh
  - dns resolution fails (`could not resolve address 'a63559aa-6052-483a-baa8-33837fa5b928.tcp-router.default.cf.bosh'`)
  - haproxy refuses to start
  - which leads to the whole failure of the deployment process

Defining the `resolvers` on server node will allow the haproxy to start and resolving the dns later, after the targeted VMs are initialized by bosh.