### PR TITLE
Fix infinite sleep after reload

### DIFF
--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -19,7 +19,8 @@ reload_daemon() {
     echo "$(date): Reloading HAProxy"
     # Relay the reload signal to the master process
     kill -USR2 "$(cat ${PID_FILE})"
-    sleep infinity
+    # Wait until master terminates
+    while kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;
 }
 
 update_certs() {
@@ -107,7 +108,7 @@ haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
 
 <%- if !run_in_foreground -%>
 # Since HAProxy requires Daemonized mode for its `nbproc` multi-process feature
-# to work properly, and BPM requires the process to stay running, wait for the 
+# to work properly, and BPM requires the process to stay running, wait for the
 # HAProxy main process to terminate
 while kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;
 <%- end -%>


### PR DESCRIPTION
This applies the same logic for fixing monit restarts after HAproxy crashes to when HAproxy has been reloaded.