### PR TITLE
fix(haproxy)!: remove nbproc property

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -39,11 +39,8 @@ consumes:
     optional: true
 
 properties:
-  ha_proxy.nbproc:
-    description: "Optional number of processes per VM"
-    default: 1
   ha_proxy.nbthread:
-    description: "Optional number of threads per VM (EXPERIMENTAL)"
+    description: "Optional number of threads per VM"
     default: 1
   ha_proxy.syslog_server:
     description: "An IPv4 address optionally followed by a colon and a UDP port. It can also be an IPv6 address or filesystem path to a UNIX domain socket."

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -228,12 +228,6 @@ global
   <%- if properties.ha_proxy.global_config -%>
     <%= p("ha_proxy.global_config") %>
   <%- end -%>
-  <%- if p("ha_proxy.nbproc") > 1  -%>
-    <%- if p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr"
-			raise("ha_proxy.syslog_server cannot be stdout or stderr when ha_proxy.nbproc > 1. Try /dev/log instead")
-		end -%>
-    nbproc <%= p("ha_proxy.nbproc") %>
-  <%- end -%>
   <%- if p("ha_proxy.nbthread") > 1 -%>
     nbthread <%= p("ha_proxy.nbthread") %>
   <%- end -%>
@@ -255,13 +249,7 @@ global
   <%- if_p("ha_proxy.max_rewrite") do -%>
     tune.maxrewrite <%= p("ha_proxy.max_rewrite") %>
   <%- end -%>
-  <%- if p("ha_proxy.nbproc") > 1 -%>
-    <%- 1.upto(p("ha_proxy.nbproc")) do |proc| -%>
-    stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 expose-fd listeners level admin process <%= proc%>
-    <%- end -%>
-  <%- else -%>
     stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 expose-fd listeners level admin
-  <%- end -%>
     stats timeout 2m
     ssl-default-bind-options <%= ssl_flags %>
     ssl-default-bind-ciphers <%= p("ha_proxy.ssl_ciphers") %>
@@ -304,12 +292,8 @@ defaults
     <%- end -%>
 
 <% if p("ha_proxy.stats_enable") -%>
-  <%- 1.upto(p("ha_proxy.nbproc")) do |proc| %>
-listen stats_<%= proc %>
-    bind <%= stat_prefix %><%= stat_port + (proc - 1) %>
-    <%- if p("ha_proxy.nbproc") > 1 -%>
-    bind-process <%= proc %>
-    <%- end -%>
+listen stats
+    bind <%= stat_prefix %><%= stat_port %>
     acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
     http-request deny unless private
     mode http
@@ -318,7 +302,6 @@ listen stats_<%= proc %>
     stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
-  <%- end -%>
 <% end -%>
 
 <% if p("ha_proxy.enable_health_check_http") %>

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -107,8 +107,6 @@ echo "$(date): Starting HAProxy"
 haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
 
 <%- if !run_in_foreground -%>
-# Since HAProxy requires Daemonized mode for its `nbproc` multi-process feature
-# to work properly, and BPM requires the process to stay running, wait for the
-# HAProxy main process to terminate
+# wait for the HAProxy main process to terminate
 while kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;
 <%- end -%>

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -107,53 +107,6 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
-  context 'when ha_proxy.nbproc is provided' do
-    let(:properties) do
-      {
-        'nbproc' => 3,
-        'syslog_server' => '/dev/log'
-      }
-    end
-
-    it 'configures the number of processes' do
-      expect(global).to include('nbproc 3')
-    end
-
-    context 'when nbproc is more than 1' do
-      it 'configures a stats socket per process' do
-        expect(global).to include('stats socket /var/vcap/sys/run/haproxy/stats1.sock mode 600 expose-fd listeners level admin process 1')
-        expect(global).to include('stats socket /var/vcap/sys/run/haproxy/stats2.sock mode 600 expose-fd listeners level admin process 2')
-        expect(global).to include('stats socket /var/vcap/sys/run/haproxy/stats3.sock mode 600 expose-fd listeners level admin process 3')
-      end
-    end
-
-    context 'when nbproc is 1' do
-      let(:properties) do
-        {
-          'nbproc' => 1
-        }
-      end
-
-      it 'configures a single stats socket' do
-        expect(global).to include('stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 expose-fd listeners level admin')
-      end
-    end
-
-    context 'when the syslog_server is the default and there is more than one process' do
-      let(:properties) do
-        {
-          'nbproc' => 3
-        }
-      end
-
-      it 'returns a meaningful error message' do
-        expect do
-          global
-        end.to raise_error /ha_proxy.syslog_server cannot be stdout or stderr when ha_proxy.nbproc > 1/
-      end
-    end
-  end
-
   context 'when ha_proxy.nbthread is provided' do
     let(:properties) do
       {

--- a/spec/haproxy/templates/haproxy_config/stats_listener_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/stats_listener_spec.rb
@@ -10,7 +10,6 @@ describe 'config/haproxy.config stats listener' do
   context 'when ha_proxy.stats_enable is true' do
     let(:default_properties) do
       {
-        'nbproc' => 2,
         'syslog_server' => '/dev/log',
         'stats_enable' => true,
         'stats_user' => 'admin',
@@ -21,31 +20,18 @@ describe 'config/haproxy.config stats listener' do
 
     let(:properties) { default_properties }
 
-    let(:stats_listener_proc1) { haproxy_conf['listen stats_1'] }
-    let(:stats_listener_proc2) { haproxy_conf['listen stats_2'] }
+    let(:stats_listener) { haproxy_conf['listen stats'] }
 
     it 'sets up a stats listener for each process' do
-      expect(stats_listener_proc1).to include('bind *:9000')
-      expect(stats_listener_proc1).to include('bind-process 1')
-      expect(stats_listener_proc1).to include('acl private src 0.0.0.0/32')
-      expect(stats_listener_proc1).to include('http-request deny unless private')
-      expect(stats_listener_proc1).to include('mode http')
-      expect(stats_listener_proc1).to include('stats enable')
-      expect(stats_listener_proc1).to include('stats hide-version')
-      expect(stats_listener_proc1).to include('stats realm "Haproxy Statistics"')
-      expect(stats_listener_proc1).to include('stats uri /foo')
-      expect(stats_listener_proc1).to include('stats auth admin:secret')
-
-      expect(stats_listener_proc2).to include('bind *:9001')
-      expect(stats_listener_proc2).to include('bind-process 2')
-      expect(stats_listener_proc2).to include('acl private src 0.0.0.0/32')
-      expect(stats_listener_proc2).to include('http-request deny unless private')
-      expect(stats_listener_proc2).to include('mode http')
-      expect(stats_listener_proc2).to include('stats enable')
-      expect(stats_listener_proc2).to include('stats hide-version')
-      expect(stats_listener_proc2).to include('stats realm "Haproxy Statistics"')
-      expect(stats_listener_proc2).to include('stats uri /foo')
-      expect(stats_listener_proc2).to include('stats auth admin:secret')
+      expect(stats_listener).to include('bind *:9000')
+      expect(stats_listener).to include('acl private src 0.0.0.0/32')
+      expect(stats_listener).to include('http-request deny unless private')
+      expect(stats_listener).to include('mode http')
+      expect(stats_listener).to include('stats enable')
+      expect(stats_listener).to include('stats hide-version')
+      expect(stats_listener).to include('stats realm "Haproxy Statistics"')
+      expect(stats_listener).to include('stats uri /foo')
+      expect(stats_listener).to include('stats auth admin:secret')
     end
 
     context 'when ha_proxy.trusted_stats_cidrs is set' do
@@ -54,8 +40,7 @@ describe 'config/haproxy.config stats listener' do
       end
 
       it 'has the correct acl' do
-        expect(stats_listener_proc1).to include('acl private src 1.2.3.4/32')
-        expect(stats_listener_proc2).to include('acl private src 1.2.3.4/32')
+        expect(stats_listener).to include('acl private src 1.2.3.4/32')
       end
     end
 
@@ -65,8 +50,7 @@ describe 'config/haproxy.config stats listener' do
       end
 
       it 'overrides the default bind address' do
-        expect(stats_listener_proc1).to include('bind 1.2.3.4:5000')
-        expect(stats_listener_proc2).to include('bind 1.2.3.4:5001')
+        expect(stats_listener).to include('bind 1.2.3.4:5000')
       end
     end
   end


### PR DESCRIPTION
As of version 2.5 HAProxy no longer supports the nbproc global option. We
therefore remove it from this bosh release as well.