### PR TITLE
Prepare for renaming label `approved` to `run-ci`

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -422,7 +422,7 @@ resources:
       access_token: ((github.access_token))
       repository:   cloudfoundry/haproxy-boshrelease
       base_branch:  master
-      labels:       [approved]
+      labels:       [approved, run-ci]
 
   - name: stemcell-xenial
     type: bosh-io-stemcell


### PR DESCRIPTION
The term 'approved' is overloaded with general PR approval.
This change makes it clear that the label enables automated PR validation via CI.