### PR TITLE
Fix reload grace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/acceptance-tests/acceptance_tests_suite_test.go
+++ b/acceptance-tests/acceptance_tests_suite_test.go
@@ -145,22 +145,26 @@ func expect421(resp *http.Response, err error) {
 }
 
 func expectTLSUnknownCertificateAuthorityErr(err error) {
-	checkTLSErr(err, "tls: unknown certificate authority")
+	checkNetOpErr(err, "tls: unknown certificate authority")
 }
 
 func expectTLSHandshakeFailureErr(err error) {
-	checkTLSErr(err, "tls: handshake failure")
+	checkNetOpErr(err, "tls: handshake failure")
 }
 
 func expectTLSCertificateRequiredErr(err error) {
-	checkTLSErr(err, "tls: certificate required")
+	checkNetOpErr(err, "tls: certificate required")
 }
 
 func expectTLSUnrecognizedNameErr(err error) {
-	checkTLSErr(err, "tls: unrecognized name")
+	checkNetOpErr(err, "tls: unrecognized name")
 }
 
-func checkTLSErr(err error, expectString string) {
+func expectConnectionRefusedErr(err error) {
+	checkNetOpErr(err, "connect: connection refused")
+}
+
+func checkNetOpErr(err error, expectString string) {
 	Expect(err).To(HaveOccurred())
 	urlErr, ok := err.(*url.Error)
 	Expect(ok).To(BeTrue())

--- a/acceptance-tests/bosh_helpers.go
+++ b/acceptance-tests/bosh_helpers.go
@@ -292,7 +292,9 @@ func reloadHAProxy(haproxyInfo haproxyInfo) {
 }
 
 func drainHAProxy(haproxyInfo haproxyInfo) {
-	_, _, err := runOnRemote(haproxyInfo.SSHUser, haproxyInfo.PublicIP, haproxyInfo.SSHPrivateKey, "sudo /var/vcap/jobs/haproxy/bin/drain")
-	Expect(err).NotTo(HaveOccurred())
-	time.Sleep(1 * time.Second)
+	go func() {
+		_, _, err := runOnRemote(haproxyInfo.SSHUser, haproxyInfo.PublicIP, haproxyInfo.SSHPrivateKey, "sudo /var/vcap/jobs/haproxy/bin/drain")
+		Expect(err).NotTo(HaveOccurred())
+	}()
+	time.Sleep(5 * time.Second)
 }

--- a/acceptance-tests/bosh_helpers.go
+++ b/acceptance-tests/bosh_helpers.go
@@ -290,3 +290,9 @@ func reloadHAProxy(haproxyInfo haproxyInfo) {
 	Expect(err).NotTo(HaveOccurred())
 	time.Sleep(10 * time.Second)
 }
+
+func drainHAProxy(haproxyInfo haproxyInfo) {
+	_, _, err := runOnRemote(haproxyInfo.SSHUser, haproxyInfo.PublicIP, haproxyInfo.SSHPrivateKey, "sudo /var/vcap/jobs/haproxy/bin/drain")
+	Expect(err).NotTo(HaveOccurred())
+	time.Sleep(1 * time.Second)
+}

--- a/acceptance-tests/drain_test.go
+++ b/acceptance-tests/drain_test.go
@@ -1,0 +1,76 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"time"
+)
+
+var _ = Describe("Drain Test", func() {
+	opsfileDrainTimeout := `---
+# Enable health check
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/enable_health_check_http?
+  value: true
+# Enable draining
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/drain_enable?
+  value: true
+# Set grace period to 10s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/drain_frontend_grace_time?
+  value: 10
+# Set drain period to 10s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/drain_timeout?
+  value: 10
+`
+	It("Honors grace and drain periods", func() {
+		backendDeploymentName := "haproxy-backend"
+		// For this test we will use a second HAProxy as pre-existing healthy 'backend'
+		haproxyBackendPort := 12000
+		backendHaproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        backendDeploymentName,
+		}, []string{}, map[string]interface{}{}, true)
+		defer deleteDeployment(backendDeploymentName)
+
+		closeLocalServer, backendLocalPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(backendHaproxyInfo, haproxyBackendPort, backendLocalPort)
+		defer closeTunnel()
+
+		// Now deploy test HAProxy with 'haproxy-backend' configured as backend
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    80,
+			haproxyBackendServers: []string{backendHaproxyInfo.PublicIP},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileDrainTimeout}, map[string]interface{}{}, true)
+
+		// Verify that instance is in a running state
+		Expect(boshInstances(deploymentNameForTestNode())[0].ProcessState).To(Equal("running"))
+
+		By("The healthcheck health endpoint should report a 200 status code")
+		expect200(http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP)))
+
+		By("Sending a request to HAProxy works")
+		expectTestServer200(http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP)))
+
+		By("Draining HAproxy should first shut down health check, listeners still working")
+		drainHAProxy(haproxyInfo)
+		_, err := http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP))
+		expectConnectionRefusedErr(err)
+		expectTestServer200(http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP)))
+		time.Sleep(10 * time.Second)
+
+		By("After grace period has passed, draining should set in, disabling listeners")
+		_, err = http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP))
+		expectConnectionRefusedErr(err)
+		_, err = http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+		expectConnectionRefusedErr(err)
+	})
+})

--- a/acceptance-tests/go.mod
+++ b/acceptance-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/haproxy-boshrelease/acceptance-tests
 
-go 1.16
+go 1.18
 
 require (
 	github.com/bramvdbogaerde/go-scp v0.0.0-20210527193300-acf430e39785
@@ -10,4 +10,12 @@ require (
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -665,7 +665,7 @@ properties:
     description: Time in seconds after SIGUSR1 signal is sent in the drain script until monit stops the processes
     default: 30
   ha_proxy.drain_frontend_grace_time:
-    description: Time in seconds after SIGUSR1 signal is sent in the drain script until the frontends stop accepting connections
+    description: Time in seconds after health checks have been shut down until SIGUSR1 signal is sent to make the frontends stop accepting connections
     default: 0
   ha_proxy.backend_prefer_local_az:
     description: |

--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -22,18 +22,21 @@ fi
 
 pid="$(cat ${pidfile})"
 
-haproxy_pids=$(pgrep -P $pid -l | grep 'haproxy$' | awk '{print $1}')
+haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)
+<%- if p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr" -%>
+haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)
+<%- else -%>
+haproxy_master_pid=$(pgrep -P "$pid" -x haproxy)
+<%- end -%>
 
 <% if p("ha_proxy.enable_health_check_http") %>
-echo "disable frontend health_check_http_url" | socat stdio unix-connect:${sockfile}
-echo "$(date): triggering grace period for process ${haproxy_pid}" >> ${logfile}
+echo "disable frontend health_check_http_url" | /usr/local/bin/socat stdio unix-connect:${sockfile}
+echo "$(date): triggering grace period for process ${haproxy_master_pid}" >> ${logfile}
 sleep <%= p("ha_proxy.drain_frontend_grace_time") -%>
 <% end -%>
 
-for haproxy_pid in $haproxy_pids; do
-  kill -USR1 "${haproxy_pid}"
-  echo "$(date): triggering drain for process ${haproxy_pid}" >> ${logfile}
-done
+kill -USR1 "${haproxy_master_pid}"
+echo "$(date): triggering drain for process ${haproxy_master_pid}" >> ${logfile}
 
 echo <%= p("ha_proxy.drain_timeout") -%>
 

--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -29,15 +29,15 @@ haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)
 haproxy_master_pid=$(pgrep -P "$pid" -x haproxy)
 <%- end -%>
 
-<% if p("ha_proxy.enable_health_check_http") %>
+<%- if p("ha_proxy.enable_health_check_http") -%>
 echo "disable frontend health_check_http_url" | /usr/local/bin/socat stdio unix-connect:${sockfile}
 echo "$(date): triggering grace period for process ${haproxy_master_pid}" >> ${logfile}
 sleep <%= p("ha_proxy.drain_frontend_grace_time") -%>
-<% end -%>
+<%- end -%>
 
 kill -USR1 "${haproxy_master_pid}"
 echo "$(date): triggering drain for process ${haproxy_master_pid}" >> ${logfile}
 
 echo <%= p("ha_proxy.drain_timeout") -%>
 
-<% end -%>
+<%- end -%>

--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -4,6 +4,7 @@
 set -e
 
 pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
+sockfile=/var/vcap/sys/run/haproxy/stats.sock
 logfile=/var/vcap/sys/log/haproxy/drain.log
 
 <% if not p("ha_proxy.drain_enable") -%>
@@ -22,6 +23,12 @@ fi
 pid="$(cat ${pidfile})"
 
 haproxy_pids=$(pgrep -P $pid -l | grep 'haproxy$' | awk '{print $1}')
+
+<% if p("ha_proxy.enable_health_check_http") %>
+echo "disable frontend health_check_http_url" | socat stdio unix-connect:${sockfile}
+echo "$(date): triggering grace period for process ${haproxy_pid}" >> ${logfile}
+sleep <%= p("ha_proxy.drain_frontend_grace_time") -%>
+<% end -%>
 
 for haproxy_pid in $haproxy_pids; do
   kill -USR1 "${haproxy_pid}"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -222,9 +222,6 @@ end
 global
     log <%= p('ha_proxy.syslog_server') %> len <%= p('ha_proxy.log_max_length') %> format <%= p('ha_proxy.log_format') %> syslog <%= p('ha_proxy.log_level') %>
     daemon
-  <%- if p("ha_proxy.drain_enable") -%>
-    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f * 1000).to_i %>
-  <%- end -%>
   <%- if properties.ha_proxy.global_config -%>
     <%= p("ha_proxy.global_config") %>
   <%- end -%>
@@ -311,9 +308,6 @@ listen health_check_http_url
     monitor-uri /health
     acl http-routers_down nbsrv(<%= backends.first[:name] %>) eq 0
     monitor fail if http-routers_down
-    <% if p("ha_proxy.drain_enable") -%>
-    monitor fail if { stopping }
-    <% end -%>
 <% end -%>
 
 <% if_p("ha_proxy.resolvers") do |resolvers| -%>

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -299,25 +299,16 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
-  context 'when ha_proxy.drain_enable is true' do
+  context 'when ha_proxy.drain_enable is false' do
     let(:properties) do
       {
-        'drain_enable' => true
+        'drain_enable' => false,
+        'drain_frontend_grace_time' => 12
       }
     end
 
-      context 'when ha_proxy.drain_enable is false' do
-        let(:properties) do
-          {
-            'drain_enable' => false,
-            'drain_frontend_grace_time' => 12
-          }
-        end
-
-        it 'aborts with a meaningful error message' do
-          expect { global }.to raise_error(/Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/)
-        end
-      end
+    it 'aborts with a meaningful error message' do
+      expect { global }.to raise_error(/Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/)
     end
   end
 

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -306,22 +306,6 @@ describe 'config/haproxy.config global and default options' do
       }
     end
 
-    it 'has a default grace period of 0 milliseconds' do
-      expect(global).to include('grace 0')
-    end
-
-    context('when ha_proxy.drain_frontend_grace_time is provided') do
-      let(:properties) do
-        {
-          'drain_enable' => true,
-          'drain_frontend_grace_time' => 12
-        }
-      end
-
-      it 'overrides the default grace period' do
-        expect(global).to include('grace 12000')
-      end
-
       context 'when ha_proxy.drain_enable is false' do
         let(:properties) do
           {

--- a/spec/haproxy/templates/haproxy_config/healthcheck_listener_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/healthcheck_listener_spec.rb
@@ -22,20 +22,6 @@ describe 'config/haproxy.config healthcheck listeners' do
       expect(healthcheck_listener).to include('monitor-uri /health')
       expect(healthcheck_listener).to include('acl http-routers_down nbsrv(http-routers-http1) eq 0')
       expect(healthcheck_listener).to include('monitor fail if http-routers_down')
-      expect(healthcheck_listener).not_to include('monitor fail if { stopping }')
-    end
-
-    context 'when ha_proxy.drain_enable is true' do
-      let(:properties) do
-        {
-          'enable_health_check_http' => true,
-          'drain_enable' => true
-        }
-      end
-
-      it 'includes monitor fail if { stopping }' do
-        expect(healthcheck_listener).to include('monitor fail if { stopping }')
-      end
     end
 
     context 'when only http2 backend servers are available' do


### PR DESCRIPTION
- Remove grace keyword as it is unsafe to use with reloads ( see [docs section](https://docs.haproxy.org/2.5/configuration.html#grace) )
- Shutdown health check externally via socket api
- Clear separation between grace time and drain time:
  - grace = health check down, listeners up. new connections are still accepted
  - drain = listeners down, new connections are refused, old connections still handled
- We no longer run both grace and drain in parallel, but rather first shut down health checks and sleep for grace period, THEN shut down listeners and tell BOSH to wait for drain period.
- During reloads, nothing changes on the health checks (line has been removed)
- This should prevent health check problems during reload as well as
- Improve speed of reloads as the handover of old connections to new HAproxy instances happens much quicker now