### PR TITLE
Bump haproxy version to 2.5.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.5.7.tar.gz:
-  size: 3832801
-  object_id: 7427e80b-f2b1-4d20-6176-644309b53c63
-  sha: sha256:e29f6334c6bdb521f63ddf335e2621bd2164503b99cf1f495b6f56ff9f3c164e
+haproxy/haproxy-2.5.8.tar.gz:
+  size: 3838130
+  object_id: fd7defc3-6a29-4083-5046-fcaac9cd296f
+  sha: sha256:8477167a4785757f35f478a584c9a0aadd77122a2acbe7276aafaa53b69b03ac
 haproxy/hatop:
   size: 72445
   object_id: 17a5f66c-bbc1-4e4d-681c-e36420d3e0f5

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,17 +1,14 @@
 # abort script on failures
 set -euxo pipefail
 
-# https://www.lua.org/ftp/lua-5.4.3.tar.gz
-LUA_VERSION=5.4.3
 
-# https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.gz
-PCRE_VERSION=10.40
+LUA_VERSION=5.4.3  # https://www.lua.org/ftp/lua-5.4.3.tar.gz
 
-# http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
-SOCAT_VERSION=1.7.4.1
+PCRE_VERSION=10.40  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.gz
 
-# https://www.haproxy.org/download/2.5/src/haproxy-2.5.7.tar.gz
-HAPROXY_VERSION=2.5.7
+SOCAT_VERSION=1.7.4.1  # http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
+
+HAPROXY_VERSION=2.5.8  # http://www.haproxy.org/download/2.5/src/haproxy-2.5.8.tar.gz
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 


### PR DESCRIPTION

Automatic bump from version 2.5.7 to version 2.5.8, downloaded from http://www.haproxy.org/download/2.5/src/haproxy-2.5.8.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
