### PR TITLE
Bump lua version to 5.4.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,10 @@ haproxy/hatop:
   size: 72445
   object_id: 17a5f66c-bbc1-4e4d-681c-e36420d3e0f5
   sha: sha256:a58450560686a429bfd6b3c8732f68f9043fa5ef2be5fac0218f48babfe57cbf
-haproxy/lua-5.4.3.tar.gz:
-  size: 358216
-  object_id: 22238d40-0c0e-4bf2-7090-448b0ae68aa2
-  sha: sha256:f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb
+haproxy/lua-5.4.4.tar.gz:
+  size: 456032
+  object_id: b5f58edc-a0ee-4e20-6a97-fb5ea6cef486
+  sha: sha256:2a2bfce37f5270b95fbc230c5cb0c5bc182d3ff55a2979e1970dfa541fc93af1
 haproxy/pcre2-10.40.tar.gz:
   size: 2359622
   object_id: 3a0e0202-481e-4df9-63fe-7080a130223e

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,17 +1,14 @@
 # abort script on failures
 set -euxo pipefail
 
-# https://www.lua.org/ftp/lua-5.4.3.tar.gz
-LUA_VERSION=5.4.3
 
-# https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.gz
-PCRE_VERSION=10.40
+LUA_VERSION=5.4.4  # https://api.github.com/repos/lua/lua/tarball/v5.4.4
 
-# http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
-SOCAT_VERSION=1.7.4.1
+PCRE_VERSION=10.40  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.gz
 
-# https://www.haproxy.org/download/2.5/src/haproxy-2.5.7.tar.gz
-HAPROXY_VERSION=2.5.7
+SOCAT_VERSION=1.7.4.1  # http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz
+
+HAPROXY_VERSION=2.5.7  # https://www.haproxy.org/download/2.5/src/haproxy-2.5.7.tar.gz
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 


### PR DESCRIPTION

Automatic bump from version 5.4.3 to version 5.4.4, downloaded from https://api.github.com/repos/lua/lua/tarball/v5.4.4.

After merge, consider releasing a new version of haproxy-boshrelease.
