### PR TITLE
Re-add credential vars for AWS/GitHub for autobump

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -418,6 +418,10 @@ jobs:
                 PR_ORG: cloudfoundry
                 PR_LABEL: run-ci
 
+                AWS_ACCESS_KEY: ((aws.access_key))
+                AWS_SECRET_KEY: ((aws.secret_key))
+                GITHUB_COM_TOKEN: ((github.access_token))
+
 resource_types:
   - name: slack-notification
     type: docker-image


### PR DESCRIPTION
they got lost while reverting a whitespace-changing commit