### PR TITLE
Enable autobump for hatop

### DIFF
--- a/ci/scripts/autobump-dependencies.py
+++ b/ci/scripts/autobump-dependencies.py
@@ -258,7 +258,7 @@ class GithubDependency(Dependency):
             if latest_version < current_version and current_raw.startswith(self.pinned_version):
                 latest_version = current_version
                 latest_release = Release(
-                    rel.body,
+                    rel.title,
                     rel.tarball_url,
                     f"{self.name}-{str(current_version)}.tar.gz",
                     current_version,
@@ -398,6 +398,13 @@ def main() -> None:
             "10",
             "https://github.com/PCRE2Project/pcre2",
             tagname_prefix="pcre2-",
+        ),
+        GithubDependency(
+            "hatop",
+            "HATOP_VERSION",
+            "0",
+            "https://github.com/jhunt/hatop",
+            tagname_prefix="v",
         ),
         # ttar (currently a submodule to https://github.com/jhunt/ttar, no new releases. Manual bump only.)
     ]

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ haproxy/haproxy-2.5.8.tar.gz:
   size: 3838130
   object_id: fd7defc3-6a29-4083-5046-fcaac9cd296f
   sha: sha256:8477167a4785757f35f478a584c9a0aadd77122a2acbe7276aafaa53b69b03ac
-haproxy/hatop:
-  size: 72445
-  object_id: 17a5f66c-bbc1-4e4d-681c-e36420d3e0f5
-  sha: sha256:a58450560686a429bfd6b3c8732f68f9043fa5ef2be5fac0218f48babfe57cbf
+haproxy/hatop-0.8.2.tar.gz:
+  size: 138030
+  object_id: eca866ad-3c8f-4526-51d1-23179c1bbda8
+  sha: sha256:99f9cd9ec1bc2bb8b84da276e670002fe993f5b26e65c15f65e40fdcb42616cb
 haproxy/lua-5.4.4.tar.gz:
   size: 360876
   object_id: 5b2652c4-3c00-4d2d-742d-dda229e95bac

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -10,6 +10,8 @@ SOCAT_VERSION=1.7.4.3  # http://www.dest-unreach.org/socat/download/socat-1.7.4.
 
 HAPROXY_VERSION=2.5.8  # http://www.haproxy.org/download/2.5/src/haproxy-2.5.8.tar.gz
 
+HATOP_VERSION=0.8.0  # https://github.com/jhunt/hatop/releases/v0.8.0
+
 mkdir ${BOSH_INSTALL_TARGET}/bin
 
 echo "Extracting lua..."
@@ -63,8 +65,9 @@ pushd haproxy-${HAPROXY_VERSION}
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy
 popd
 
-echo "Installing hatop..."
-cp haproxy/hatop ${BOSH_INSTALL_TARGET}/bin/hatop
+echo "Unpackaging and installing hatop..."
+tar xzf -C haproxy/hatop --strip-components=1 haproxy/hatop-${HATOP_VERSION}.tar.gz
+cp haproxy/bin/hatop ${BOSH_INSTALL_TARGET}/bin/hatop
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/hatop
 cp hatop-wrapper ${BOSH_INSTALL_TARGET}/
 chmod 755 ${BOSH_INSTALL_TARGET}/hatop-wrapper

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -10,7 +10,7 @@ SOCAT_VERSION=1.7.4.3  # http://www.dest-unreach.org/socat/download/socat-1.7.4.
 
 HAPROXY_VERSION=2.5.8  # http://www.haproxy.org/download/2.5/src/haproxy-2.5.8.tar.gz
 
-HATOP_VERSION=0.8.0  # https://github.com/jhunt/hatop/releases/v0.8.0
+HATOP_VERSION=0.8.2  # https://api.github.com/repos/jhunt/hatop/tarball/v0.8.2
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 
@@ -66,8 +66,9 @@ pushd haproxy-${HAPROXY_VERSION}
 popd
 
 echo "Unpackaging and installing hatop..."
-tar xzf -C haproxy/hatop --strip-components=1 haproxy/hatop-${HATOP_VERSION}.tar.gz
-cp haproxy/bin/hatop ${BOSH_INSTALL_TARGET}/bin/hatop
+mkdir hatop
+tar xzf haproxy/hatop-${HATOP_VERSION}.tar.gz -C hatop --strip-components=1 
+cp hatop/bin/hatop ${BOSH_INSTALL_TARGET}/bin/hatop
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/hatop
 cp hatop-wrapper ${BOSH_INSTALL_TARGET}/
 chmod 755 ${BOSH_INSTALL_TARGET}/hatop-wrapper

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -5,5 +5,5 @@ files:
 - haproxy/pcre2-*.tar.gz
 - haproxy/socat-*.tar.gz
 - haproxy/lua-*.tar.gz
-- haproxy/hatop
+- haproxy/hatop-*.tar.gz
 - hatop-wrapper


### PR DESCRIPTION
* Change hatop to a versioned artifact (tar.gz)
* enable auto-bumper for hatop via GitHub release / tag tarball
* Bump hatop to 0.8.2
