### PR TITLE
feat: rate-limiting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,22 @@ bundle exec guard
 ```
 
 #### PR Validation
-PRs will be automatically tested by https://concourse.cfi.sapcloud.io/teams/main/pipelines/haproxy-boshrelease once a maintainer has labelled the PR with the `approved` label
+PRs will be automatically tested by https://concourse.cfi.sapcloud.io/teams/main/pipelines/haproxy-boshrelease once a maintainer has labelled the PR with the `run-ci` label
 
 #### Unit Test Debugging
+Unit/rspec Tests and linters can be run locally to verify correct functionality before pushing to the CI system.
+
+```shell
+# install the necessary dependencies, once
+bundle package
+
+# run the linter to identify any issues
+bundle exec rake lint
+
+# run the rspec / unit tests for the configuration generation
+bundle exec rake spec
+```
+
 Unit/rspec Tests can also be debugged when needed. See for example the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension. You can follow the "Launch without configuration" instructions for the extension, just set the "Debug command line" input to `bundle exec rspec <filepath>`.
 
 ### Acceptance tests

--- a/README.md
+++ b/README.md
@@ -54,48 +54,42 @@ cut a new final release for you.
 
 ### Unit Tests and Linting
 
+#### PR Validation
+PRs will be automatically tested by https://concourse.cfi.sapcloud.io/teams/main/pipelines/haproxy-boshrelease once a maintainer has labelled the PR with the `run-ci` label
+
+#### Local Test Execution
+Unit/rspec Tests and linters can be run locally to verify correct functionality before pushing to the CI system.
 If you change any erb logic in the jobs directory please add a corresponding test to `spec`.
 
-To run these tests:
+```bash
+# install the necessary dependencies, once
+bundle package
 ```
+
+```bash
+# run the rspec / unit tests for the configuration generation
 cd haproxy_boshrelease
 bundle install
 bundle exec rake spec
 ```
 
-To run lint with rubocop
-```
+```bash
+# run the linter (rubocop) to identify any issues
 cd haproxy_boshrelease
 bundle install
 bundle exec rake lint
 ```
 
-To watch the tests while developing
-```
+```bash
+# watch the tests while developing
 cd haproxy_boshrelease
 bundle install
 bundle exec guard
 ```
 
-#### PR Validation
-PRs will be automatically tested by https://concourse.cfi.sapcloud.io/teams/main/pipelines/haproxy-boshrelease once a maintainer has labelled the PR with the `run-ci` label
-
-#### Unit Test Debugging
-Unit/rspec Tests and linters can be run locally to verify correct functionality before pushing to the CI system.
-
-```shell
-# install the necessary dependencies, once
-bundle package
-
-# run the linter to identify any issues
-bundle exec rake lint
-
-# run the rspec / unit tests for the configuration generation
-bundle exec rake spec
-```
-
-Unit/rspec Tests can also be debugged when needed. See for example the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension. You can follow the "Launch without configuration" instructions for the extension, just set the "Debug command line" input to `bundle exec rspec <filepath>`.
+#### Test Debugging
+Unit/rspec Tests can also be debugged/stepped through when needed. See for example the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension. You can follow the "Launch without configuration" instructions for the extension, just set the "Debug command line" input to `bundle exec rspec <filepath>`.
 
 ### Acceptance tests
 
-See [here](/acceptance-tests/README.md)
+See [acceptance-tests README](/acceptance-tests/README.md).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ bundle install
 bundle exec guard
 ```
 
+#### PR Validation
 PRs will be automatically tested by https://concourse.cfi.sapcloud.io/teams/main/pipelines/haproxy-boshrelease once a maintainer has labelled the PR with the `approved` label
+
+#### Unit Test Debugging
+Unit/rspec Tests can also be debugged when needed. See for example the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension. You can follow the "Launch without configuration" instructions for the extension, just set the "Debug command line" input to `bundle exec rspec <filepath>`.
 
 ### Acceptance tests
 

--- a/acceptance-tests/rate_limit_test.go
+++ b/acceptance-tests/rate_limit_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("Rate-Limiting", func() {
+var _ = Describe("Rate-Limiting", func() {
 	It("Request Based Limiting Works", func() {
 		requestLimit := 5
 		opsfileRequestRateLimit := fmt.Sprintf(`---
@@ -44,11 +44,11 @@ var _ = FDescribe("Rate-Limiting", func() {
 		successfulRequestCount := 0
 		for i := 0; i < testRequestCount; i++ {
 			resp, err := http.Get(fmt.Sprintf("http://%s/foo", haproxyInfo.PublicIP))
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			switch resp.StatusCode {
-			case 200:
+			case http.StatusOK:
 				successfulRequestCount++
-			case 429:
+			case http.StatusTooManyRequests:
 				if firstFailure == -1 {
 					firstFailure = i
 				}
@@ -61,7 +61,7 @@ var _ = FDescribe("Rate-Limiting", func() {
 		Expect(successfulRequestCount).To(Equal(requestLimit))
 	})
 
-	FIt("Connection Based Limiting Works", func() { //TODO: remove focus
+	It("Connection Based Limiting Works", func() { //TODO: remove focus
 		connLimit := 5
 		opsfileConnectionsRateLimit := fmt.Sprintf(`---
 - type: replace
@@ -114,5 +114,71 @@ var _ = FDescribe("Rate-Limiting", func() {
 		Expect(firstFailure).To(Equal(connLimit))
 		By("The total amount of successful connections per time window should equal the Connection Rate Limit")
 		Expect(successfulRequestCount).To(Equal(connLimit))
+	})
+
+	It("Both types of rate limiting work in parallel", func() { //TODO: remove focus
+		requestLimit := 5
+		connLimit := 6  // needs to be higher than request limit for this test
+		// connection based rate-limiting has priority over request based rate-limiting so we expect some sucesses, then one status 429 response, then no response at all
+		opsfileConnectionsRateLimit := fmt.Sprintf(`---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit?/requests
+  value: %d
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit/window_size?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit/table_size?
+  value: 100
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit/block?
+  value: true
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit?/connections
+  value: %d
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit/window_size?
+  value: 100s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit/table_size?
+  value: 100
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit/block?
+  value: true
+`, requestLimit, connLimit)
+		haproxyBackendPort := 12000
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileConnectionsRateLimit}, map[string]interface{}{}, true)
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+
+		testRequestCount := int(float64(connLimit) * 1.5)
+		By("Receiving successful responses until request limit is reached, then response status 429 until TCP connection limit is reached, then no response at all")
+		for i := 0; i < testRequestCount; i++ {
+			rt := &http.Transport{
+				DisableKeepAlives: true,
+			}
+			client := &http.Client{Transport: rt}
+			resp, err := client.Get(fmt.Sprintf("http://%s/foo", haproxyInfo.PublicIP))
+			if i < requestLimit {
+				// sucessful requests
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			} else if i == requestLimit {
+				// request limit reached --> 429 response
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusTooManyRequests))
+			} else {
+				// TCP connection limit reached --> no response
+				Expect(err).To(HaveOccurred())
+			}
+		}
 	})
 })

--- a/acceptance-tests/rate_limit_test.go
+++ b/acceptance-tests/rate_limit_test.go
@@ -1,0 +1,118 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("Rate-Limiting", func() {
+	It("Request Based Limiting Works", func() {
+		requestLimit := 5
+		opsfileRequestRateLimit := fmt.Sprintf(`---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit?/requests
+  value: %d
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit/window_size?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit/table_size?
+  value: 100
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/requests_rate_limit/block?
+  value: true
+`, requestLimit)
+
+		haproxyBackendPort := 12000
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileRequestRateLimit}, map[string]interface{}{}, true)
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+
+		testRequestCount := int(float64(requestLimit) * 1.5)
+		firstFailure := -1
+		successfulRequestCount := 0
+		for i := 0; i < testRequestCount; i++ {
+			resp, err := http.Get(fmt.Sprintf("http://%s/foo", haproxyInfo.PublicIP))
+			Expect(err).To(BeNil())
+			switch resp.StatusCode {
+			case 200:
+				successfulRequestCount++
+			case 429:
+				if firstFailure == -1 {
+					firstFailure = i
+				}
+			}
+		}
+
+		By("The first request should fail after we've sent the amount of requests specified in the Request Rate Limit")
+		Expect(firstFailure).To(Equal(requestLimit))
+		By("The total amount of successful requests per time window should equal the Request Rate Limit")
+		Expect(successfulRequestCount).To(Equal(requestLimit))
+	})
+
+	FIt("Connection Based Limiting Works", func() { //TODO: remove focus
+		connLimit := 5
+		opsfileConnectionsRateLimit := fmt.Sprintf(`---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit?/connections
+  value: %d
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit/window_size?
+  value: 100s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit/table_size?
+  value: 100
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/connections_rate_limit/block?
+  value: true
+`, connLimit)
+		haproxyBackendPort := 12000
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileConnectionsRateLimit}, map[string]interface{}{}, true)
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+
+		testRequestCount := int(float64(connLimit) * 1.5)
+		firstFailure := -1
+		successfulRequestCount := 0
+		for i := 0; i < testRequestCount; i++ {
+			rt := &http.Transport{
+				DisableKeepAlives: true,
+			}
+			client := &http.Client{Transport: rt}
+			resp, err := client.Get(fmt.Sprintf("http://%s/foo", haproxyInfo.PublicIP))
+			if err == nil {
+				if resp.StatusCode == 200 {
+					successfulRequestCount++
+					continue
+				}
+			}
+			if firstFailure == -1 {
+				firstFailure = i
+			}
+		}
+
+		By("The first connection should fail after we've sent the amount of requests specified in the Connection Rate Limit")
+		Expect(firstFailure).To(Equal(connLimit))
+		By("The total amount of successful connections per time window should equal the Connection Rate Limit")
+		Expect(successfulRequestCount).To(Equal(connLimit))
+	})
+})

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,10 @@
+# Fixes
+
+# New Features
+- HAProxy Rate-Limiting is now configurable! See docs/rate_limiting.md
+
+# Upgrades
+
+# Acknowledgements
+
+Thanks @maxmoehl, @a18e for the PR / fixes!

--- a/docs/rate_limiting.md
+++ b/docs/rate_limiting.md
@@ -1,0 +1,121 @@
+# Client IP based Rate Limiting
+Rate limits in HAProxy are based on stick-tables. The concept of stick-tables is explained in [this blog article](https://www.haproxy.com/blog/introduction-to-haproxy-stick-tables/). It covers all relevant parts and gives a general idea on how one could rate limit based on certain attributes.
+
+HAProxy-boshrelease can be configured to enforce these rate limits based on requests and connections per second per IP.
+
+## Configuration Options
+See also `jobs/haproxy/spec`:
+
+There are two rate limit configuration groups:
+- `connections_rate_limit` for connection based rate limiting on OSI layer 4/TCP
+- `requests_rate_limit` for request based rate limiting on OSI layer 7/HTTP
+
+Both groups contain the (roughly) same attributes :
+- `requests` (for `requests_rate_limit`) and `connections` (for `connections_rate_limit`): the amount of requests/connections that are allowed within a time window (see `window_size`) before further incoming requests/connections are denied/blocked
+- `window_size`: Window size for counting connections
+- `table_size`: Size of the stick table in which the IPs and counters are stored.
+- `block`: Whether or not to block connections. If `block` is disabled (or not provided), incoming requests/connections will still be tracked in the respective stick-tables, but will not be denied.
+
+## Effects of Rate Limiting
+Once a rate-limit is reached, haproxy-boshrelease will no longer proxy incoming request from the rate-limited client IP to a backend. Depending on the type of rate limiting, haproxy will respond with one of the following:
+
+### Request based Rate Limiting
+HAProxy responds the client with HTTP Status Code: `429: Too Many Requests`.
+
+### Connection based Rate Limiting
+The TCP connection will be rejected. This would for example show up as `Empty reply from server` for a `curl`-client.
+This will not result in a log statement on HAProxy side, which can make tracing issues more difficult.
+
+> Note:
+> If both rate-limits are reached simultaneously (e.g. if they are configured identically and every incoming HTTP request uses a new TCP connection), connection based rate-limiting will come into effect first, resulting in a dropped TCP connection.
+
+
+## Configuration Examples
+> Note:
+> The following example assume only a `http-in` frontend is configured, a `https-in` frontend would behave identically
+
+### Count Incoming Requests Only (No blocking)
+#### Configuration (`deployments/haproxy/config.yml`)
+```yml
+config:
+    # [...]
+    requests_rate_limit:
+        window_size: 10s
+        table_size: 1m
+```
+
+#### Resulting `haproxy.config`
+```ini
+backend st_http_req_rate
+    stick-table type ip size 1m expire 10s store http_req_rate(10s)
+# [...]
+frontend http-in
+    tcp-request content track-sc1 src table st_http_req_rate
+```
+
+
+### Request based Rate Limiting Fully Active
+#### Configuration
+```yml
+config:
+    # [...]
+    requests_rate_limit:
+        requests: 10
+        window_size: 10s
+        table_size: 1m
+        block: true
+```
+#### Resulting `haproxy.config`
+```ini
+backend st_http_req_rate
+    stick-table type ip size 1m expire 10s store http_req_rate(10s)
+# [...]
+frontend http-in
+    tcp-request content track-sc1 src table st_http_req_rate
+    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
+```
+
+
+### Both Types Active
+#### Configuration
+```yml
+config:
+    # [...]
+    requests_rate_limit:
+        requests: 10
+        window_size: 10s
+        table_size: 1m
+        block: true
+    connections_rate_limit:
+        connections: 10
+        window_size: 10s
+        table_size: 1m
+        block: true
+```
+#### Resulting `haproxy.config`
+```ini
+backend st_http_req_rate
+    stick-table type ip size 1m expire 10s store http_req_rate(10s)
+
+backend st_tcp_conn_rate
+    stick-table type ip size 1m expire 10s store conn_rate(10s)
+# [...]
+frontend http-in
+    # [...]
+    tcp-request content track-sc1 src table st_http_req_rate
+    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 10 }
+
+    tcp-request content track-sc0 src table st_tcp_conn_rate
+    tcp-request connection reject if { sc_conn_rate(0) gt 10}
+```
+
+## Querying current stick-table status
+To give us more insights into what is going on inside HAProxy with regards to its rate limits we can query the stats socket to get the raw table data:
+
+```bash
+$ echo "show table st_http_req_rate" | socat /var/vcap/sys/run/haproxy/stats.sock -
+# table: st_http_req_rate, type: ip, size:10485760, used:1
+0x56495f3dc3d0: key=172.18.0.1 use=0 exp=7618 http_req_rate(10000)=10
+```
+
+> Please note you will likely need 'sudo' permission to run socat.

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -677,22 +677,22 @@ properties:
   ha_proxy.always_allow_body_http10:
     description: Always allow a body to be sent when using HTTP/1.0. By default HAProxy denies GET/HEAD/DELETE requests with a body when using HTTP/1.0 due to potential request smuggling attacks. See https://github.com/haproxy/haproxy/commit/e136bd12a32970bc90d862d5fe09ea1952b62974
     default: false
-  
+
   ha_proxy.requests_rate_limit.requests:
-    description: How many requests are allowed in the given time window from one IP address.
+    description: How many requests are allowed in the given time window from one IP address. See docs/rate_limiting.md
   ha_proxy.requests_rate_limit.window_size:
-    description: Window size for counting requests.
+    description: Window size for counting requests. See docs/rate_limiting.md
   ha_proxy.requests_rate_limit.table_size:
-    description: Size of the stick table in which the IPs and counters are stored.
+    description: Size of the stick table in which the IPs and counters are stored. See docs/rate_limiting.md
   ha_proxy.requests_rate_limit.block:
-    description: Whether or not to block requests.
+    description: Whether or not to block requests. See docs/rate_limiting.md
     default: false
   ha_proxy.connections_rate_limit.connections:
-    description: How many connections are allowed in the given time window from one IP address.
+    description: How many connections are allowed in the given time window from one IP address. See docs/rate_limiting.md
   ha_proxy.connections_rate_limit.window_size:
-    description: Window size for counting connections.
+    description: Window size for counting connections. See docs/rate_limiting.md
   ha_proxy.connections_rate_limit.table_size:
-    description: Size of the stick table in which the IPs and counters are stored.
+    description: Size of the stick table in which the IPs and counters are stored. See docs/rate_limiting.md
   ha_proxy.connections_rate_limit.block:
-    description: Whether or not to block connections.
+    description: Whether or not to block connections. See docs/rate_limiting.md
     default: false

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -656,7 +656,7 @@ properties:
     description: The number of file descriptors HAProxy can have open at one time
     default: 256000
   ha_proxy.max_connections:
-    description: Number of simultanous connections HAProxy supports handling
+    description: Number of simultaneous connections HAProxy supports handling
     default: 64000
   ha_proxy.drain_enable:
     description: Send SIGUSR1 signal to all haproxy processes in a drain script in order to gracefully shutdown
@@ -672,8 +672,27 @@ properties:
       Prefer backend servers which are located on the same availability zone. Note that this only affects servers provided via the http_backend link property. Servers provided via the tcp backend_link will automatically prefer the local AZ.
     default: false
   ha_proxy.enable_http2:
-    description: Enables ingress (frontend) and egress (backend) HTTP/2 ALPN negotiation. Egress (backend) HTTP protocol version may be overriden by `ha_proxy.backend_ssl`, `ha_proxy.disable_backend_http2_websockets` and `ha_proxy.backend_match_http_protocol`.
+    description: Enables ingress (frontend) and egress (backend) HTTP/2 ALPN negotiation. Egress (backend) HTTP protocol version may be overridden by `ha_proxy.backend_ssl`, `ha_proxy.disable_backend_http2_websockets` and `ha_proxy.backend_match_http_protocol`.
     default: false
   ha_proxy.always_allow_body_http10:
     description: Always allow a body to be sent when using HTTP/1.0. By default HAProxy denies GET/HEAD/DELETE requests with a body when using HTTP/1.0 due to potential request smuggling attacks. See https://github.com/haproxy/haproxy/commit/e136bd12a32970bc90d862d5fe09ea1952b62974
+    default: false
+  
+  ha_proxy.requests_rate_limit.requests:
+    description: How many requests are allowed in the given time window from one IP address.
+  ha_proxy.requests_rate_limit.window_size:
+    description: Window size for counting requests.
+  ha_proxy.requests_rate_limit.table_size:
+    description: Size of the stick table in which the IPs and counters are stored.
+  ha_proxy.requests_rate_limit.block:
+    description: Whether or not to block requests.
+    default: false
+  ha_proxy.connections_rate_limit.connections:
+    description: How many connections are allowed in the given time window from one IP address.
+  ha_proxy.connections_rate_limit.window_size:
+    description: Window size for counting connections.
+  ha_proxy.connections_rate_limit.table_size:
+    description: Size of the stick table in which the IPs and counters are stored.
+  ha_proxy.connections_rate_limit.block:
+    description: Whether or not to block connections.
     default: false

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -1,3 +1,4 @@
+<%- # see https://bosh.io/docs/jobs/#properties for documentation of bosh ERB templates -%>
 <% if properties.ha_proxy.raw_config -%>
 <%= p("ha_proxy.raw_config") %>
 <%- else -%>
@@ -320,6 +321,16 @@ resolvers default
   <%- end -%>
 <% end -%>
 
+<% if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do %>
+backend sc_http_req_rate
+    stick-table type ip size <%= p("ha_proxy.requests_rate_limit.table_size") %> expire <%= p("ha_proxy.requests_rate_limit.window_size") %> store http_req_rate(<%= p("ha_proxy.requests_rate_limit.window_size") %>)
+<% end %>
+
+<% if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do %>
+backend sc_tcp_conn_rate
+    stick-table type ip size <%= p("ha_proxy.connections_rate_limit.table_size") %> expire <%= p("ha_proxy.connections_rate_limit.window_size") %> store conn_rate(<%= p("ha_proxy.connections_rate_limit.window_size") %>)
+<% end %>
+
 <% unless p("ha_proxy.disable_http") -%>
 # HTTP Frontend {{{
 frontend http-in
@@ -328,13 +339,25 @@ frontend http-in
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
-  <%- if_p("ha_proxy.cidr_whitelist") do -%>
-    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
-    tcp-request content accept if whitelist
-  <%- end -%>
   <%- if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
+  <%- end -%>
+  <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size", "ha_proxy.connections_rate_limit.connections") do -%>
+    <%- if p("ha_proxy.connections_rate_limit.block") -%>
+      tcp-request connection reject if { sc0_conn_rate gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
+    <%- end -%>
+    tcp-request connection track-sc0 src table sc_tcp_conn_rate
+  <%- end -%>
+  <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size", "ha_proxy.requests_rate_limit.requests") do -%>
+    <%- if p("ha_proxy.requests_rate_limit.block") -%>
+    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
+    <%- end -%>
+    tcp-request content track-sc1 src table sc_http_req_rate
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_whitelist") do -%>
+    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
+    tcp-request content accept if whitelist
   <%- end -%>
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
@@ -425,13 +448,25 @@ frontend https-in
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
-  <%- if_p("ha_proxy.cidr_whitelist") do -%>
-    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
-    tcp-request content accept if whitelist
-  <%- end -%>
   <%- if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
+  <%- end -%>
+  <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size", "ha_proxy.connections_rate_limit.connections") do -%>
+    <%- if p("ha_proxy.connections_rate_limit.block") -%>
+    tcp-request connection reject if { sc0_conn_rate gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
+    <%- end -%>
+    tcp-request connection track-sc0 src table sc_tcp_conn_rate
+  <%- end -%>
+  <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size", "ha_proxy.requests_rate_limit.requests") do -%>
+    <%- if p("ha_proxy.requests_rate_limit.block") -%>
+    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
+    <%- end -%>
+    tcp-request content track-sc1 src table sc_http_req_rate
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_whitelist") do -%>
+    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
+    tcp-request content accept if whitelist
   <%- end -%>
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -351,7 +351,7 @@ frontend http-in
     tcp-request content track-sc1 src table st_http_req_rate
     <%- if_p("ha_proxy.requests_rate_limit.block", "ha_proxy.requests_rate_limit.requests") do |block, requests| -%>
       <%-if block -%>
-    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= requests %> }
+    http-request deny status 429 if { sc_http_req_rate(1) gt <%= requests %> }
       <%- end -%>
     <%- end -%>
   <%- end -%>
@@ -464,7 +464,7 @@ frontend https-in
     tcp-request content track-sc1 src table st_http_req_rate
     <%- if_p("ha_proxy.requests_rate_limit.block", "ha_proxy.requests_rate_limit.requests") do |block, requests| -%>
       <%-if block -%>
-    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= requests %> }
+    http-request deny status 429 if { sc_http_req_rate(1) gt <%= requests %> }
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -322,12 +322,12 @@ resolvers default
 <% end -%>
 
 <% if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do %>
-backend sc_http_req_rate
+backend st_http_req_rate
     stick-table type ip size <%= p("ha_proxy.requests_rate_limit.table_size") %> expire <%= p("ha_proxy.requests_rate_limit.window_size") %> store http_req_rate(<%= p("ha_proxy.requests_rate_limit.window_size") %>)
 <% end %>
 
 <% if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do %>
-backend sc_tcp_conn_rate
+backend st_tcp_conn_rate
     stick-table type ip size <%= p("ha_proxy.connections_rate_limit.table_size") %> expire <%= p("ha_proxy.connections_rate_limit.window_size") %> store conn_rate(<%= p("ha_proxy.connections_rate_limit.window_size") %>)
 <% end %>
 
@@ -344,16 +344,16 @@ frontend http-in
     tcp-request content reject if blacklist
   <%- end -%>
   <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size", "ha_proxy.connections_rate_limit.connections") do -%>
+    tcp-request connection track-sc0 src table st_tcp_conn_rate
     <%- if p("ha_proxy.connections_rate_limit.block") -%>
-      tcp-request connection reject if { sc0_conn_rate gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
+    tcp-request connection reject if { sc_conn_rate(0) gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
     <%- end -%>
-    tcp-request connection track-sc0 src table sc_tcp_conn_rate
   <%- end -%>
   <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size", "ha_proxy.requests_rate_limit.requests") do -%>
+    tcp-request content track-sc1 src table st_http_req_rate
     <%- if p("ha_proxy.requests_rate_limit.block") -%>
     http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
     <%- end -%>
-    tcp-request content track-sc1 src table sc_http_req_rate
   <%- end -%>
   <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
@@ -453,16 +453,16 @@ frontend https-in
     tcp-request content reject if blacklist
   <%- end -%>
   <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size", "ha_proxy.connections_rate_limit.connections") do -%>
+    tcp-request connection track-sc0 src table st_tcp_conn_rate
     <%- if p("ha_proxy.connections_rate_limit.block") -%>
-    tcp-request connection reject if { sc0_conn_rate gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
+    tcp-request connection reject if { sc_conn_rate(0) gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
     <%- end -%>
-    tcp-request connection track-sc0 src table sc_tcp_conn_rate
   <%- end -%>
   <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size", "ha_proxy.requests_rate_limit.requests") do -%>
+    tcp-request content track-sc1 src table st_http_req_rate
     <%- if p("ha_proxy.requests_rate_limit.block") -%>
     http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
     <%- end -%>
-    tcp-request content track-sc1 src table sc_http_req_rate
   <%- end -%>
   <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -343,15 +343,15 @@ frontend http-in
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
   <%- end -%>
-  <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size", "ha_proxy.connections_rate_limit.connections") do -%>
+  <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do -%>
     tcp-request connection track-sc0 src table st_tcp_conn_rate
-    <%- if p("ha_proxy.connections_rate_limit.block") -%>
+    <%- if p("ha_proxy.connections_rate_limit.block") && if_p("ha_proxy.connections_rate_limit.connections") -%>
     tcp-request connection reject if { sc_conn_rate(0) gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
     <%- end -%>
   <%- end -%>
-  <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size", "ha_proxy.requests_rate_limit.requests") do -%>
+  <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do -%>
     tcp-request content track-sc1 src table st_http_req_rate
-    <%- if p("ha_proxy.requests_rate_limit.block") -%>
+    <%- if p("ha_proxy.requests_rate_limit.block") && if_p("ha_proxy.requests_rate_limit.requests") -%>
     http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
     <%- end -%>
   <%- end -%>
@@ -452,15 +452,15 @@ frontend https-in
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
   <%- end -%>
-  <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size", "ha_proxy.connections_rate_limit.connections") do -%>
+  <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do -%>
     tcp-request connection track-sc0 src table st_tcp_conn_rate
-    <%- if p("ha_proxy.connections_rate_limit.block") -%>
+    <%- if p("ha_proxy.connections_rate_limit.block") && if_p("ha_proxy.connections_rate_limit.connections") -%>
     tcp-request connection reject if { sc_conn_rate(0) gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
     <%- end -%>
   <%- end -%>
-  <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size", "ha_proxy.requests_rate_limit.requests") do -%>
+  <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do -%>
     tcp-request content track-sc1 src table st_http_req_rate
-    <%- if p("ha_proxy.requests_rate_limit.block") -%>
+    <%- if p("ha_proxy.requests_rate_limit.block") && if_p("ha_proxy.requests_rate_limit.requests") -%>
     http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
     <%- end -%>
   <%- end -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -321,14 +321,14 @@ resolvers default
   <%- end -%>
 <% end -%>
 
-<% if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do %>
+<% if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do |table_size, window_size| %>
 backend st_http_req_rate
-    stick-table type ip size <%= p("ha_proxy.requests_rate_limit.table_size") %> expire <%= p("ha_proxy.requests_rate_limit.window_size") %> store http_req_rate(<%= p("ha_proxy.requests_rate_limit.window_size") %>)
+    stick-table type ip size <%= table_size %> expire <%= window_size %> store http_req_rate(<%= window_size %>)
 <% end %>
 
-<% if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do %>
+<% if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do |table_size, window_size| %>
 backend st_tcp_conn_rate
-    stick-table type ip size <%= p("ha_proxy.connections_rate_limit.table_size") %> expire <%= p("ha_proxy.connections_rate_limit.window_size") %> store conn_rate(<%= p("ha_proxy.connections_rate_limit.window_size") %>)
+    stick-table type ip size <%= table_size %> expire <%= window_size %> store conn_rate(<%= window_size %>)
 <% end %>
 
 <% unless p("ha_proxy.disable_http") -%>
@@ -339,25 +339,29 @@ frontend http-in
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
-  <%- if_p("ha_proxy.cidr_blacklist") do -%>
-    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
-    tcp-request content reject if blacklist
-  <%- end -%>
   <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do -%>
     tcp-request connection track-sc0 src table st_tcp_conn_rate
-    <%- if p("ha_proxy.connections_rate_limit.block") && if_p("ha_proxy.connections_rate_limit.connections") -%>
-    tcp-request connection reject if { sc_conn_rate(0) gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
+    <%- if_p("ha_proxy.connections_rate_limit.block", "ha_proxy.connections_rate_limit.connections") do |block, connections| -%>
+      <%-if block -%>
+    tcp-request connection reject if { sc_conn_rate(0) gt <%= connections %> }
+      <%- end -%>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do -%>
     tcp-request content track-sc1 src table st_http_req_rate
-    <%- if p("ha_proxy.requests_rate_limit.block") && if_p("ha_proxy.requests_rate_limit.requests") -%>
-    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
+    <%- if_p("ha_proxy.requests_rate_limit.block", "ha_proxy.requests_rate_limit.requests") do |block, requests| -%>
+      <%-if block -%>
+    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= requests %> }
+      <%- end -%>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_blacklist") do -%>
+    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
+    tcp-request content reject if blacklist
   <%- end -%>
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
@@ -448,25 +452,29 @@ frontend https-in
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
-  <%- if_p("ha_proxy.cidr_blacklist") do -%>
-    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
-    tcp-request content reject if blacklist
-  <%- end -%>
   <%- if_p("ha_proxy.connections_rate_limit.table_size", "ha_proxy.connections_rate_limit.window_size") do -%>
     tcp-request connection track-sc0 src table st_tcp_conn_rate
-    <%- if p("ha_proxy.connections_rate_limit.block") && if_p("ha_proxy.connections_rate_limit.connections") -%>
-    tcp-request connection reject if { sc_conn_rate(0) gt <%= p("ha_proxy.connections_rate_limit.connections") %> }
+    <%- if_p("ha_proxy.connections_rate_limit.block", "ha_proxy.connections_rate_limit.connections") do |block, connections| -%>
+      <%-if block -%>
+    tcp-request connection reject if { sc_conn_rate(0) gt <%= connections %> }
+      <%- end -%>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.requests_rate_limit.table_size", "ha_proxy.requests_rate_limit.window_size") do -%>
     tcp-request content track-sc1 src table st_http_req_rate
-    <%- if p("ha_proxy.requests_rate_limit.block") && if_p("ha_proxy.requests_rate_limit.requests") -%>
-    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= p("ha_proxy.requests_rate_limit.requests") %> }
+    <%- if_p("ha_proxy.requests_rate_limit.block", "ha_proxy.requests_rate_limit.requests") do |block, requests| -%>
+      <%-if block -%>
+    http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt <%= requests %> }
+      <%- end -%>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_blacklist") do -%>
+    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
+    tcp-request content reject if blacklist
   <%- end -%>
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject

--- a/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
@@ -18,13 +18,12 @@ describe 'config/haproxy.config rate limiting' do
     }
   end
 
-  context 'when ha_proxy.requests_rate_limit properties "requests", "window_size", "table_size" are provided' do
+  context 'when ha_proxy.requests_rate_limit properties "window_size", "table_size" are provided' do
     let(:backend_req_rate) { haproxy_conf['backend st_http_req_rate'] }
 
     let(:request_limit_base_properties) do
       {
         'requests_rate_limit' => {
-          'requests' => '5',
           'window_size' => '10s',
           'table_size' => '10m'
         }
@@ -46,9 +45,9 @@ describe 'config/haproxy.config rate limiting' do
       expect(frontend_https).to include('tcp-request content track-sc1 src table st_http_req_rate')
     end
 
-    context 'when requests_rate_limit.block is also provided' do
+    context 'when "requests" and "block" are also provided' do
       let(:properties) do
-        temp_properties.deep_merge({ 'requests_rate_limit' => { 'block' => 'true' } })
+        temp_properties.deep_merge({ 'requests_rate_limit' => { 'requests' => '5', 'block' => 'true' } })
       end
 
       it 'adds http-request deny condition to http-in and https-in frontends' do
@@ -60,13 +59,12 @@ describe 'config/haproxy.config rate limiting' do
     end
   end
 
-  context 'when ha_proxy.connections_rate_limit properties "connections", "window_size", "table_size" are provided' do
+  context 'when ha_proxy.connections_rate_limit properties "window_size", "table_size" are provided' do
     let(:backend_conn_rate) { haproxy_conf['backend st_tcp_conn_rate'] }
 
     let(:connection_limit_base_properties) do
       {
         'connections_rate_limit' => {
-          'connections' => '5',
           'window_size' => '10s',
           'table_size' => '10m'
         }
@@ -88,9 +86,9 @@ describe 'config/haproxy.config rate limiting' do
       expect(frontend_https).to include('tcp-request connection track-sc0 src table st_tcp_conn_rate')
     end
 
-    context 'when connections_rate_limit.block is also provided' do
+    context 'when "connections" and "block" are also provided' do
       let(:properties) do
-        temp_properties.deep_merge({ 'connections_rate_limit' => { 'block' => 'true' } })
+        temp_properties.deep_merge({ 'connections_rate_limit' => { 'connections' => '5', 'block' => 'true' } })
       end
 
       it 'adds http-request deny condition to http-in and https-in frontends' do

--- a/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
@@ -53,7 +53,9 @@ describe 'config/haproxy.config rate limiting' do
 
       it 'adds http-request deny condition to http-in and https-in frontends' do
         expect(frontend_http).to include('http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 5 }')
+        expect(frontend_http).to include('tcp-request content track-sc1 src table st_http_req_rate')
         expect(frontend_https).to include('http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 5 }')
+        expect(frontend_https).to include('tcp-request content track-sc1 src table st_http_req_rate')
       end
     end
   end
@@ -93,7 +95,9 @@ describe 'config/haproxy.config rate limiting' do
 
       it 'adds http-request deny condition to http-in and https-in frontends' do
         expect(frontend_http).to include('tcp-request connection reject if { sc_conn_rate(0) gt 5 }')
+        expect(frontend_http).to include('tcp-request connection track-sc0 src table st_tcp_conn_rate')
         expect(frontend_https).to include('tcp-request connection reject if { sc_conn_rate(0) gt 5 }')
+        expect(frontend_https).to include('tcp-request connection track-sc0 src table st_tcp_conn_rate')
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
@@ -51,9 +51,9 @@ describe 'config/haproxy.config rate limiting' do
       end
 
       it 'adds http-request deny condition to http-in and https-in frontends' do
-        expect(frontend_http).to include('http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 5 }')
+        expect(frontend_http).to include('http-request deny status 429 if { sc_http_req_rate(1) gt 5 }')
         expect(frontend_http).to include('tcp-request content track-sc1 src table st_http_req_rate')
-        expect(frontend_https).to include('http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 5 }')
+        expect(frontend_https).to include('http-request deny status 429 if { sc_http_req_rate(1) gt 5 }')
         expect(frontend_https).to include('tcp-request content track-sc1 src table st_http_req_rate')
       end
     end

--- a/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+describe 'config/haproxy.config rate limiting' do
+  let(:haproxy_conf) do
+    parse_haproxy_config(template.render({ 'ha_proxy' => properties }))
+  end
+
+  let(:frontend_http) { haproxy_conf['frontend http-in'] }
+  let(:frontend_https) { haproxy_conf['frontend https-in'] }
+
+  let(:properties) { {} }
+
+  let(:default_properties) do
+    {
+      'ssl_pem' => 'ssl pem contents' # required for https-in frontend
+    }
+  end
+
+  context 'when ha_proxy.requests_rate_limit properties "requests", "window_size", "table_size" are provided' do
+    let(:backend_req_rate) { haproxy_conf['backend sc_http_req_rate'] }
+
+    let(:request_limit_base_properties) do
+      {
+        'requests_rate_limit' => {
+          'requests' => '5',
+          'window_size' => '10s',
+          'table_size' => '10m'
+        }
+      }
+    end
+
+    let(:temp_properties) do # temp_properties is required since we cannot deep_merge :properties in its own let/assignment block
+      default_properties.deep_merge(request_limit_base_properties)
+    end
+
+    let(:properties) { temp_properties }
+
+    it 'sets up stick-tables' do
+      expect(backend_req_rate).to include('stick-table type ip size 10m expire 10s store http_req_rate(10s)')
+    end
+
+    it 'tracks requests in stick tables' do
+      expect(frontend_http).to include('tcp-request content track-sc1 src table sc_http_req_rate')
+      expect(frontend_https).to include('tcp-request content track-sc1 src table sc_http_req_rate')
+    end
+
+    context 'when requests_rate_limit.block is also provided' do
+      let(:properties) do
+        temp_properties.deep_merge({ 'requests_rate_limit' => { 'block' => 'true' } })
+      end
+
+      it 'adds http-request deny condition to http-in and https-in frontends' do
+        expect(frontend_http).to include('http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 5 }')
+        expect(frontend_https).to include('http-request deny status 429 content-type "text/plain" string "429: Too Many Requests" if { sc_http_req_rate(1) gt 5 }')
+      end
+    end
+  end
+
+  context 'when ha_proxy.connections_rate_limit properties "connections", "window_size", "table_size" are provided' do
+    let(:backend_conn_rate) { haproxy_conf['backend sc_tcp_conn_rate'] }
+
+    let(:connection_limit_base_properties) do
+      {
+        'connections_rate_limit' => {
+          'connections' => '5',
+          'window_size' => '10s',
+          'table_size' => '10m'
+        }
+      }
+    end
+
+    let(:temp_properties) do # temp_properties is required since we cannot deep_merge :properties in its own let/assignment block
+      default_properties.deep_merge(connection_limit_base_properties)
+    end
+
+    let(:properties) { temp_properties }
+
+    it 'sets up stick-tables' do
+      expect(backend_conn_rate).to include('stick-table type ip size 10m expire 10s store conn_rate(10s)')
+    end
+
+    it 'tracks connections in stick tables' do
+      expect(frontend_http).to include('tcp-request connection track-sc0 src table sc_tcp_conn_rate')
+      expect(frontend_https).to include('tcp-request connection track-sc0 src table sc_tcp_conn_rate')
+    end
+
+    context 'when connections_rate_limit.block is also provided' do
+      let(:properties) do
+        temp_properties.deep_merge({ 'connections_rate_limit' => { 'block' => 'true' } })
+      end
+
+      it 'adds http-request deny condition to http-in and https-in frontends' do
+        expect(frontend_http).to include('tcp-request connection reject if { sc0_conn_rate gt 5 }')
+        expect(frontend_https).to include('tcp-request connection reject if { sc0_conn_rate gt 5 }')
+      end
+    end
+  end
+end

--- a/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/rate_limit_spec.rb
@@ -19,7 +19,7 @@ describe 'config/haproxy.config rate limiting' do
   end
 
   context 'when ha_proxy.requests_rate_limit properties "requests", "window_size", "table_size" are provided' do
-    let(:backend_req_rate) { haproxy_conf['backend sc_http_req_rate'] }
+    let(:backend_req_rate) { haproxy_conf['backend st_http_req_rate'] }
 
     let(:request_limit_base_properties) do
       {
@@ -42,8 +42,8 @@ describe 'config/haproxy.config rate limiting' do
     end
 
     it 'tracks requests in stick tables' do
-      expect(frontend_http).to include('tcp-request content track-sc1 src table sc_http_req_rate')
-      expect(frontend_https).to include('tcp-request content track-sc1 src table sc_http_req_rate')
+      expect(frontend_http).to include('tcp-request content track-sc1 src table st_http_req_rate')
+      expect(frontend_https).to include('tcp-request content track-sc1 src table st_http_req_rate')
     end
 
     context 'when requests_rate_limit.block is also provided' do
@@ -59,7 +59,7 @@ describe 'config/haproxy.config rate limiting' do
   end
 
   context 'when ha_proxy.connections_rate_limit properties "connections", "window_size", "table_size" are provided' do
-    let(:backend_conn_rate) { haproxy_conf['backend sc_tcp_conn_rate'] }
+    let(:backend_conn_rate) { haproxy_conf['backend st_tcp_conn_rate'] }
 
     let(:connection_limit_base_properties) do
       {
@@ -82,8 +82,8 @@ describe 'config/haproxy.config rate limiting' do
     end
 
     it 'tracks connections in stick tables' do
-      expect(frontend_http).to include('tcp-request connection track-sc0 src table sc_tcp_conn_rate')
-      expect(frontend_https).to include('tcp-request connection track-sc0 src table sc_tcp_conn_rate')
+      expect(frontend_http).to include('tcp-request connection track-sc0 src table st_tcp_conn_rate')
+      expect(frontend_https).to include('tcp-request connection track-sc0 src table st_tcp_conn_rate')
     end
 
     context 'when connections_rate_limit.block is also provided' do
@@ -92,8 +92,8 @@ describe 'config/haproxy.config rate limiting' do
       end
 
       it 'adds http-request deny condition to http-in and https-in frontends' do
-        expect(frontend_http).to include('tcp-request connection reject if { sc0_conn_rate gt 5 }')
-        expect(frontend_https).to include('tcp-request connection reject if { sc0_conn_rate gt 5 }')
+        expect(frontend_http).to include('tcp-request connection reject if { sc_conn_rate(0) gt 5 }')
+        expect(frontend_https).to include('tcp-request connection reject if { sc_conn_rate(0) gt 5 }')
       end
     end
   end


### PR DESCRIPTION
Allow configuration of rate-limits based on connection rate and request
rate. Each limit and it's details can be fine tuned for the given
use-case.

See `docs/rate_limiting.md` for examples/configuration.

Co-Authored-By: Alexander Nicke <alexander.nicke@sap.com>