### PR TITLE
fixes drain script failure when HAproxy not running and pidfile present

### DIFF
--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -21,9 +21,18 @@ if [[ ! -f ${pidfile} ]]; then
 fi
 
 pid="$(cat ${pidfile})"
+pid_exists=$(ps -p ${pid} | tail -n +2)
+
+if [ "${pid_exists}" = '' ]; then
+  # In case haproxy_wrapper process is stale, pid_exists will be empty,
+  # the drain job should not fail
+  echo "$(date): There was no master process for haproxy_wrapper." >> ${logfile}
+  echo 0
+  exit 0
+fi
 
 haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)
-<%- if p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr" -%>
+<%-  if p("ha_proxy.syslog_server") == "stdout" || p("ha_proxy.syslog_server") == "stderr" -%>
 haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)
 <%- else -%>
 haproxy_master_pid=$(pgrep -P "$pid" -x haproxy)

--- a/spec/haproxy/templates/drain_spec.rb
+++ b/spec/haproxy/templates/drain_spec.rb
@@ -31,6 +31,15 @@ describe 'bin/drain' do
           fi
 
           pid="$(cat ${pidfile})"
+          pid_exists=$(ps -p ${pid} | tail -n +2)
+
+          if [ "${pid_exists}" = '' ]; then
+            # In case haproxy_wrapper process is stale, pid_exists will be empty,
+            # the drain job should not fail
+            echo "$(date): There was no master process for haproxy_wrapper." >> ${logfile}
+            echo 0
+            exit 0
+          fi
 
           haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)
           haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)
@@ -69,6 +78,15 @@ describe 'bin/drain' do
             fi
 
             pid="$(cat ${pidfile})"
+            pid_exists=$(ps -p ${pid} | tail -n +2)
+
+            if [ "${pid_exists}" = '' ]; then
+              # In case haproxy_wrapper process is stale, pid_exists will be empty,
+              # the drain job should not fail
+              echo "$(date): There was no master process for haproxy_wrapper." >> ${logfile}
+              echo 0
+              exit 0
+            fi
 
             haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)
             haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)


### PR DESCRIPTION
We encountered an issue during deployment phase. Bosh filed to drain on canary VM. 
```
Task 6224192 | 23:51:20 | L executing pre-stop: ha_proxy_z2/16e2782c-adcd-4e88-b5b4-e064c9911c57 (0) (canary)
Task 6224192 | 23:51:20 | L executing drain: ha_proxy_z2/16e2782c-adcd-4e88-b5b4-e064c9911c57 (0) (canary) (00:00:03)
                        L Error: Action Failed get_task: Task b5e5ccc7-02af-4fc6-508c-f31d95f95749 result: 1 of 2 drain scripts failed. Failed Jobs: haproxy. Successful Jobs: syslog_forwarder.
Task 6224192 | 23:51:22 | Error: Action Failed get_task: Task b5e5ccc7-02af-4fc6-508c-f31d95f95749 result: 1 of 2 drain scripts failed. Failed Jobs: haproxy. Successful Jobs: syslog_forwarder.

Task 6224192 Started  Tue Aug 23 23:50:51 UTC 2022
Task 6224192 Finished Tue Aug 23 23:51:22 UTC 2022
Task 6224192 Duration 00:00:31
Task 6224192 error
Updating deployment:
  Expected task '6224192' to succeed but state is 'error'

Exit code 1

[bosh][INFO] Deprovisioning client 'd.haproxy.deploy.9b17b2'...
error: lifecycle 'deploy' for deployment 'haproxy' failed in action 'deploy'. Action output (can be empty):

exit status 1
```
After running investigation on the canary VM, we noticed that the drain script fails because the file `/var/vcap/sys/run/bpm/haproxy/haproxy.pid` still exists and non empty. 

The script checks the existence of the pidfile and reads its content then kill the child process that belongs the PID read from the pidfile. 

As the file exists and not empty, `haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)` fails with exit code `1` (process doesn't exist), which makes fail the script.

With the fix we propose, `haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper || true)`, awe handle the case of a crashed haproxy_wrapper parent process when its pidfile still exists.