### PR TITLE
Fix local docker mac acceptance

### DIFF
--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -31,6 +31,12 @@ A convenience script that does this for you is below.
 docker_restart_with_cgroupsv1() {
     SETTINGS=~/Library/Group\ Containers/group.com.docker/settings.json
 
+    if ! command -v jq >/dev/null || ! command -v sponge; then
+        echo "Requires jq and sponge. Consider installing via:"
+        echo "   brew install jq moreutils"
+        return
+    fi
+
     cgroupsV1Enabled=$(jq '.deprecatedCgroupv1' "$SETTINGS")
     if [ "$cgroupsV1Enabled" = "true" ]; then
         echo "deprecatedCgroupv1 is already set to 'true'. Acceptance tests should work."
@@ -46,6 +52,7 @@ docker_restart_with_cgroupsv1() {
         echo 'Setting "deprecatedCgroupv1" to true.'
 
         # Add the needed cgroup config to docker settings.json
+        # sponge is needed because we're updating the same file in place
         echo '{"deprecatedCgroupv1": true}' |
             jq -s '.[0] * .[1]' "$SETTINGS" - |
             sponge "$SETTINGS"
@@ -66,6 +73,7 @@ docker_restart_with_cgroupsv1
 ```
 
 ### Focussed Tests
+
 If you want to run only a specific part of the suite, you can use [focussed specs](https://onsi.github.io/ginkgo/#focused-specs)
 
 The easiest way is to just add an `F` to your `Describe`, `Context` or `It` closures.

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -72,6 +72,12 @@ docker_restart_with_cgroupsv1() {
 docker_restart_with_cgroupsv1
 ```
 
+The output at the end should be:
+```plain
+ Cgroup Driver: cgroupfs
+ Cgroup Version: 1
+```
+
 ### Focussed Tests
 
 If you want to run only a specific part of the suite, you can use [focussed specs](https://onsi.github.io/ginkgo/#focused-specs)

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -1,6 +1,6 @@
 # Acceptance Tests
 
-### Requirements:
+## Requirements
 
 * Docker installed locally
 * A matching Bionic stemcell tgz downloaded to `ci/scripts/stemcell`
@@ -10,14 +10,62 @@
 * A BPM release tgz downloaded to `ci/scripts/bpm`
   * Get it from https://bosh.io/releases/github.com/cloudfoundry/bpm-release?all=1
 
-#### Running:
+## Running
 
 ```shell
 cd acceptance-tests
 ./run-local.sh
 ```
 
-#### Focussed tests:
+### Running on Docker for Mac
+
+The BOSH Docker CPI requires cgroups v1 to be active. Docker for Mac since 4.3.x uses cgroups v2 by default.
+
+v1 can be restored with the flag `deprecatedCgroupv1` to `true` in `~/Library/Group Containers/group.com.docker/settings.json`.
+
+A convenience script that does this for you is below.
+
+**WARNING:** This will restart your Docker Desktop!
+
+```shell
+docker_restart_with_cgroupsv1() {
+    SETTINGS=~/Library/Group\ Containers/group.com.docker/settings.json
+
+    cgroupsV1Enabled=$(jq '.deprecatedCgroupv1' "$SETTINGS")
+    if [ "$cgroupsV1Enabled" = "true" ]; then
+        echo "deprecatedCgroupv1 is already set to 'true'. Acceptance tests should work."
+    else
+        echo "Stopping Docker to set the config flag deprecatedCgroupv1 = true in $SETTINGS"
+
+        while docker ps -q 2>/dev/null; do
+            launchctl stop $(launchctl list | grep docker.docker | awk '{print $3}')
+            osascript -e 'quit app "Docker"'
+            echo "Waiting for Docker daemon to stop responding."
+            sleep 1
+        done
+        echo 'Setting "deprecatedCgroupv1" to true.'
+
+        # Add the needed cgroup config to docker settings.json
+        echo '{"deprecatedCgroupv1": true}' |
+            jq -s '.[0] * .[1]' "$SETTINGS" - |
+            sponge "$SETTINGS"
+        # Restart docker desktop
+        echo "Restarting Docker"
+        open --background -a Docker
+
+        while ! docker ps -q 2>/dev/null; do
+            echo "Waiting for Docker daemon to be back up again. Sleeping 1s."
+            sleep 1
+        done
+    fi
+
+    docker info | grep "Cgroup"
+}
+
+docker_restart_with_cgroupsv1
+```
+
+### Focussed Tests
 If you want to run only a specific part of the suite, you can use [focussed specs](https://onsi.github.io/ginkgo/#focused-specs)
 
 The easiest way is to just add an `F` to your `Describe`, `Context` or `It` closures.

--- a/acceptance-tests/run-local.sh
+++ b/acceptance-tests/run-local.sh
@@ -5,6 +5,32 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")/" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+if [ "$(git status -s | wc -l)" -gt 0 ]; then
+    echo "You have changes in your Git repository. Commit or clean (e.g. git clean -f) before running."
+    echo "The build will fail otherwise."
+    echo "Git Status:"
+    git status
+    exit 1
+fi
+
+docker_mac_check_cgroupsv1() {
+    # Force cgroups v1 on Docker for Mac
+    # inspired by https://github.com/docker/for-mac/issues/6073#issuecomment-1018793677
+
+    SETTINGS=~/Library/Group\ Containers/group.com.docker/settings.json
+
+    cgroupsV1Enabled=$(jq '.deprecatedCgroupv1' "$SETTINGS")
+    if [ "$cgroupsV1Enabled" != "true" ]; then 
+        echo "deprecatedCgroupv1 should be enabled in $SETTINGS. Otherwise the acceptance tests will not run on Docker for Mac."
+        echo "Check in the README.md for a convenient script to set deprecatedCgroupv1 and restart Docker."
+        exit 1
+    fi
+}
+
+if [ "$(uname)" == "Darwin" ]; then
+    docker_mac_check_cgroupsv1
+fi
+
 # Build acceptance test image
 pushd "$SCRIPT_DIR/../ci" || exit 1
  docker build -t haproxy-boshrelease-testflight .

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -405,7 +405,7 @@ jobs:
                 type: docker-image
                 source:
                   repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
-                  tag: "2022-08-03"
+                  tag: latest
                   username: ((docker.username))
                   password: ((docker.password))
               run:

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -192,7 +192,6 @@ function main() {
       command bosh int bosh.yml \
         -o docker/cpi.yml \
         -o jumpbox-user.yml \
-        -o /usr/local/local-releases.yml \
         -v director_name=docker \
         -v internal_cidr=10.245.0.0/16 \
         -v internal_gw=10.245.0.1 \


### PR DESCRIPTION
Docker for Mac changed to using cgroups v2 by default.

These instructions help set it back to v1, as BOSH lite and the docker-cpi do not run with cgroups v2.