### PR TITLE
add release notes

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,7 +1,11 @@
+# Fixes
+- Update autobumper to create pull requests for HAProxy 2.6.x (https://github.com/cloudfoundry/haproxy-boshrelease/pull/317)
+# New Features
+- Add lua test (https://github.com/cloudfoundry/haproxy-boshrelease/pull/313)
 # Upgrades
 
 - `haproxy` has been upgraded from v2.5.8 to v2.6.5
 
 # Acknowledgements
 
-Thanks @domdom82 for the PR!
+Thanks @peanball, @b1tamara and domdom82 for your contributions

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,7 @@
+# Upgrades
+
+- `haproxy` has been upgraded from v2.5.8 to v2.6.5
+
+# Acknowledgements
+
+Thanks @domdom82 for the PR!

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.5.8.tar.gz:
-  size: 3838130
-  object_id: fd7defc3-6a29-4083-5046-fcaac9cd296f
-  sha: sha256:8477167a4785757f35f478a584c9a0aadd77122a2acbe7276aafaa53b69b03ac
+haproxy/haproxy-2.6.5.tar.gz:
+  size: 4010014
+  object_id: e4352fba-fdf4-42cc-6dfd-5d25057d4524
+  sha: sha256:ce9e19ebfcdd43e51af8a6090f1df8d512d972ddf742fa648a643bbb19056605
 haproxy/hatop-0.8.2.tar.gz:
   size: 138030
   object_id: eca866ad-3c8f-4526-51d1-23179c1bbda8

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.40  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.3  # http://www.dest-unreach.org/socat/download/socat-1.7.4.3.tar.gz
 
-HAPROXY_VERSION=2.5.8  # http://www.haproxy.org/download/2.5/src/haproxy-2.5.8.tar.gz
+HAPROXY_VERSION=2.6.5  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.5.tar.gz
 
 HATOP_VERSION=0.8.2  # https://api.github.com/repos/jhunt/hatop/tarball/v0.8.2
 

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.40  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.3  # http://www.dest-unreach.org/socat/download/socat-1.7.4.3.tar.gz
 
-HAPROXY_VERSION=2.6.5  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.5.tar.gz
+HAPROXY_VERSION=2.5.8  # http://www.haproxy.org/download/2.5/src/haproxy-2.5.8.tar.gz
 
 HATOP_VERSION=0.8.2  # https://api.github.com/repos/jhunt/hatop/tarball/v0.8.2
 


### PR DESCRIPTION
Release notes for bumping new haproxy v2.6.5 
No need to run the pipeline!