### PR TITLE
Update release to jammy stemcell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ config/settings.yml
 releases/*.tgz
 releases/**/*.tgz
 ci/scripts/stemcell/*.tgz
-ci/scripts/stemcell-xenial/*.tgz
+ci/scripts/stemcell-bionic/*.tgz
 ci/scripts/bpm/*.tgz
 dev_releases
 blobs/*

--- a/acceptance-tests/.gitignore
+++ b/acceptance-tests/.gitignore
@@ -1,0 +1,1 @@
+ginkgo-*.log

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -5,8 +5,8 @@
 * Docker installed locally
 * A matching Jammy stemcell tgz downloaded to `ci/scripts/stemcell`
   * Get it from https://bosh.io/stemcells/bosh-warden-boshlite-ubuntu-jammy-go_agent
-* A matching Xenial stemcell tgz downloaded to `ci/scripts/stemcell-xenial`
-  * Get it from https://bosh.io/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent
+* A matching Bionic stemcell tgz downloaded to `ci/scripts/stemcell-bionic`
+  * Get it from https://bosh.io/stemcells/bosh-warden-boshlite-ubuntu-bionic-go_agent
 * A BPM release tgz downloaded to `ci/scripts/bpm`
   * Get it from https://bosh.io/releases/github.com/cloudfoundry/bpm-release?all=1
 

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -92,7 +92,9 @@ So, e.g. if you want to run all tests that use mTLS, you can run:
 ```shell
 ./run-local.sh mTLS
 ```
+
 However, if you want to run exactly one specific test, make sure you pass the exact description of the matching `It` closure:
+
 ```shell
 ./run-local.sh "Correctly terminates mTLS requests"
 ```

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -83,6 +83,7 @@ The output at the end should be:
 If you want to run only a specific part of the suite, you can use [focussed specs](https://onsi.github.io/ginkgo/#focused-specs)
 
 The easiest way is to just provide the name of the tests you want to run as a command line argument like so:
+
 ```shell
 ./run-local.sh "description of the test to run"
 ```

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -87,8 +87,10 @@ The easiest way is to just provide the name of the tests you want to run as a co
 ```shell
 ./run-local.sh "description of the test to run"
 ```
+
 The argument is passed as a regular expression that will match all `Describe`, `Context` or `It` closure descriptions in the suite.
 So, e.g. if you want to run all tests that use mTLS, you can run:
+
 ```shell
 ./run-local.sh mTLS
 ```

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -82,5 +82,19 @@ The output at the end should be:
 
 If you want to run only a specific part of the suite, you can use [focussed specs](https://onsi.github.io/ginkgo/#focused-specs)
 
-The easiest way is to just add an `F` to your `Describe`, `Context` or `It` closures.
+The easiest way is to just provide the name of the tests you want to run as a command line argument like so:
+```shell
+./run-local.sh "description of the test to run"
+```
+The argument is passed as a regular expression that will match all `Describe`, `Context` or `It` closure descriptions in the suite.
+So, e.g. if you want to run all tests that use mTLS, you can run:
+```shell
+./run-local.sh mTLS
+```
+However, if you want to run exactly one specific test, make sure you pass the exact description of the matching `It` closure:
+```shell
+./run-local.sh "Correctly terminates mTLS requests"
+```
+
+Alternatively, you add an `F` to your `Describe`, `Context` or `It` closures.
 Don't forget to do a local commit before running the tests, else BOSH will fail to produce a release. The git repo must be clean before running the tests.

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -3,8 +3,8 @@
 ## Requirements
 
 * Docker installed locally
-* A matching Bionic stemcell tgz downloaded to `ci/scripts/stemcell`
-  * Get it from https://bosh.io/stemcells/bosh-warden-boshlite-ubuntu-bionic-go_agent
+* A matching Jammy stemcell tgz downloaded to `ci/scripts/stemcell`
+  * Get it from https://bosh.io/stemcells/bosh-warden-boshlite-ubuntu-jammy-go_agent
 * A matching Xenial stemcell tgz downloaded to `ci/scripts/stemcell-xenial`
   * Get it from https://bosh.io/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent
 * A BPM release tgz downloaded to `ci/scripts/bpm`

--- a/acceptance-tests/acceptance_tests_suite_test.go
+++ b/acceptance-tests/acceptance_tests_suite_test.go
@@ -154,6 +154,10 @@ func expectTLSUnknownCertificateAuthorityErr(err error) {
 	checkNetOpErr(err, "tls: unknown certificate authority")
 }
 
+func expectTLSUnknownCertificateErr(err error) {
+	checkNetOpErr(err, "tls: unknown certificate")
+}
+
 func expectTLSHandshakeFailureErr(err error) {
 	checkNetOpErr(err, "tls: handshake failure")
 }

--- a/acceptance-tests/bionic_test.go
+++ b/acceptance-tests/bionic_test.go
@@ -7,14 +7,14 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("Xenial", func() {
-	It("Correctly proxies HTTP requests when using the Xenial stemcell", func() {
+var _ = Describe("Bionic", func() {
+	It("Correctly proxies HTTP requests when using the Bionic stemcell", func() {
 
-		opsfileXenial := `---
-# Configure Xenial stemcell
+		opsfileBionic := `---
+# Configure Bionic stemcell
 - type: replace
   path: /stemcells/alias=default/os
-  value: ubuntu-xenial
+  value: ubuntu-bionic
 `
 
 		haproxyBackendPort := 12000
@@ -22,7 +22,7 @@ var _ = Describe("Xenial", func() {
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
 			deploymentName:        deploymentNameForTestNode(),
-		}, []string{opsfileXenial}, map[string]interface{}{}, true)
+		}, []string{opsfileBionic}, map[string]interface{}{}, true)
 
 		closeLocalServer, localPort := startDefaultTestServer()
 		defer closeLocalServer()

--- a/acceptance-tests/go.mod
+++ b/acceptance-tests/go.mod
@@ -7,15 +7,15 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.13.0
-	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
-	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b
+	golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect
+	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/acceptance-tests/go.sum
+++ b/acceptance-tests/go.sum
@@ -41,8 +41,9 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7 h1:WJywXQVIb56P2kAvXeMGTIgQ1ZHQxR60+F9dLsodECc=
+golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -51,8 +52,8 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -67,8 +68,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea h1:+WiDlPBBaO+h9vPNZi8uJ3k4BkKQB7Iow3aqwHVA5hI=
 golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/acceptance-tests/mtls_frontend_test.go
+++ b/acceptance-tests/mtls_frontend_test.go
@@ -159,11 +159,11 @@ var _ = Describe("mTLS", func() {
 
 		By("Using client B cert with endpoint A is not allowed")
 		_, err = httpClientB.Get("https://a.haproxy.internal")
-		expectTLSUnknownCertificateAuthorityErr(err)
+		expectTLSUnknownCertificateErr(err)
 
 		By("Using client A cert with endpoint B is not allowed")
 		_, err = httpClientA.Get("https://b.haproxy.internal")
-		expectTLSUnknownCertificateAuthorityErr(err)
+		expectTLSUnknownCertificateErr(err)
 
 		By("Making a non-mTLS request to an endpoint with optional mTLS works")
 		expectTestServer200(httpClientNonMTLS.Get("https://a.haproxy.internal"))

--- a/acceptance-tests/run-local.sh
+++ b/acceptance-tests/run-local.sh
@@ -13,6 +13,8 @@ if [ "$(git status -s | wc -l)" -gt 0 ]; then
     exit 1
 fi
 
+FOCUS="$1"
+
 docker_mac_check_cgroupsv1() {
     # Force cgroups v1 on Docker for Mac
     # inspired by https://github.com/docker/for-mac/issues/6073#issuecomment-1018793677
@@ -37,4 +39,8 @@ pushd "$SCRIPT_DIR/../ci" || exit 1
 popd || exit 1
 
 # Run acceptance tests
-docker run --rm --privileged -v "$REPO_DIR":/repo -e REPO_ROOT=/repo haproxy-boshrelease-testflight bash -c "cd /repo/ci/scripts && ./acceptance-tests"
+if [ -n "$FOCUS" ]; then
+  docker run --privileged -v "$REPO_DIR":/repo -e REPO_ROOT=/repo -e FOCUS="$FOCUS" haproxy-boshrelease-testflight bash -c "cd /repo/ci/scripts && ./acceptance-tests ; sleep infinity"
+else
+  docker run --rm --privileged -v "$REPO_DIR":/repo -e REPO_ROOT=/repo haproxy-boshrelease-testflight bash -c "cd /repo/ci/scripts && ./acceptance-tests"
+fi

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get install -y wget jq git vim nano python3-pip\
   && echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list \
   && apt-get update && apt-get install -y wget spruce && apt-get clean
 
+# Set bosh env at login
+RUN echo "source /tmp/local-bosh/director/env" >> /root/.bashrc
+
 # Install Python libraries needed for scripts
 COPY scripts/requirements.txt /requirements.txt
 RUN /usr/bin/python3 -m pip install -r /requirements.txt

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -466,7 +466,7 @@ resources:
   - name: stemcell
     type: bosh-io-stemcell
     source:
-      name: bosh-warden-boshlite-ubuntu-bionic-go_agent
+      name: bosh-warden-boshlite-ubuntu-jammy-go_agent
 
   - name: bpm
     type: bosh-io-release

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -144,7 +144,7 @@ jobs:
       - in_parallel:
         - { get: git, trigger: true, passed: [unit-tests] }
         - { get: stemcell }
-        - { get: stemcell-xenial }
+        - { get: stemcell-bionic }
         - { get: bpm }
       - task: acceptance-tests
         privileged: true
@@ -160,7 +160,7 @@ jobs:
           inputs:
             - { name: git }
             - { name: stemcell }
-            - { name: stemcell-xenial }
+            - { name: stemcell-bionic }
             - { name: bpm }
           run:
             path: ./git/ci/scripts/acceptance-tests
@@ -182,7 +182,7 @@ jobs:
     - do:
       - { get: git-pull-requests, trigger: true, version: every, passed: [unit-tests-pr] }
       - { get: stemcell }
-      - { get: stemcell-xenial }
+      - { get: stemcell-bionic }
       - { get: bpm }
       - put: git-pull-requests
         params:
@@ -203,7 +203,7 @@ jobs:
           inputs:
             - { name: git-pull-requests }
             - { name: stemcell }
-            - { name: stemcell-xenial }
+            - { name: stemcell-bionic }
             - { name: bpm }
           run:
             path: ./git-pull-requests/ci/scripts/acceptance-tests
@@ -458,10 +458,10 @@ resources:
       base_branch:  master
       labels:       [run-ci]
 
-  - name: stemcell-xenial
+  - name: stemcell-bionic
     type: bosh-io-stemcell
     source:
-      name: bosh-warden-boshlite-ubuntu-xenial-go_agent
+      name: bosh-warden-boshlite-ubuntu-bionic-go_agent
 
   - name: stemcell
     type: bosh-io-stemcell

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-set -eu
+set -e
 
 stemcell_jammy_path=$PWD/stemcell/*.tgz
 stemcell_bionic_path=$PWD/stemcell-bionic/*.tgz
 bpm_release_path=$PWD/bpm/*.tgz
+
+if [ -n "$FOCUS" ]; then
+  echo "------------------------------------------------------------------"
+  echo "FOCUS is set. Will only run tests matching '$FOCUS'"
+  echo "Docker won't be stopped afterwards, so you can debug the test."
+  echo "------------------------------------------------------------------"
+  FOCUS_ARG="-focus $FOCUS"
+fi
 
 cd ${REPO_ROOT:?required}
 echo "----- Pulling in any git submodules..."
@@ -19,7 +27,9 @@ function stop_docker() {
   service docker stop
 }
 
-trap stop_docker EXIT
+if [ -z "$FOCUS" ]; then
+  trap stop_docker EXIT
+fi
 
 source /tmp/local-bosh/director/env
 
@@ -56,4 +66,4 @@ go mod download
 echo "----- Running tests"
 
 export PATH=$PATH:$GOPATH/bin
-ginkgo -v -p -r -debug -trace -progress -randomizeAllSpecs -flakeAttempts 5
+ginkgo -v -p -r -debug -trace -progress -randomizeAllSpecs -flakeAttempts 5 $FOCUS_ARG

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -2,7 +2,7 @@
 
 set -eu
 
-stemcell_bionic_path=$PWD/stemcell/*.tgz
+stemcell_jammy_path=$PWD/stemcell/*.tgz
 stemcell_xenial_path=$PWD/stemcell-xenial/*.tgz
 bpm_release_path=$PWD/bpm/*.tgz
 
@@ -32,8 +32,8 @@ release_final_version=$(spruce json dev_releases/*/index.yml | jq -r ".builds[].
 export RELEASE_VERSION="${release_final_version}.latest"
 echo "----- Created ${RELEASE_VERSION}"
 
-echo "----- Uploading Bionic stemcell"
-bosh -n upload-stemcell $stemcell_bionic_path
+echo "----- Uploading Jammy stemcell"
+bosh -n upload-stemcell $stemcell_jammy_path
 
 echo "----- Uploading Xenial stemcell"
 bosh -n upload-stemcell $stemcell_xenial_path

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -3,7 +3,7 @@
 set -eu
 
 stemcell_jammy_path=$PWD/stemcell/*.tgz
-stemcell_xenial_path=$PWD/stemcell-xenial/*.tgz
+stemcell_bionic_path=$PWD/stemcell-bionic/*.tgz
 bpm_release_path=$PWD/bpm/*.tgz
 
 cd ${REPO_ROOT:?required}
@@ -35,8 +35,8 @@ echo "----- Created ${RELEASE_VERSION}"
 echo "----- Uploading Jammy stemcell"
 bosh -n upload-stemcell $stemcell_jammy_path
 
-echo "----- Uploading Xenial stemcell"
-bosh -n upload-stemcell $stemcell_xenial_path
+echo "----- Uploading Bionic stemcell"
+bosh -n upload-stemcell $stemcell_bionic_path
 
 echo "----- Uploading BPM"
 bosh -n upload-release $bpm_release_path

--- a/ci/scripts/shell
+++ b/ci/scripts/shell
@@ -37,6 +37,10 @@ bosh -n upload-stemcell $stemcell_path
 echo "----- Uploading BPM"
 bosh -n upload-release $bpm_release_path
 
+echo "----- Uploading os-conf (used for tests only)"
+bosh -n upload-release --sha1 386293038ae3d00813eaa475b4acf63f8da226ef \
+  https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.2
+
 export BOSH_PATH=$(which bosh)
 export BASE_MANIFEST_PATH="$PWD/manifests/haproxy.yml"
 

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -128,7 +128,7 @@ function start_docker() {
   [[ ! -d /etc/docker ]] && mkdir /etc/docker
   cat <<EOF > /etc/docker/daemon.json
 {
-  "hosts": ["${DOCKER_HOST}"],
+  "hosts": ["${DOCKER_HOST}","unix:///var/run/docker.sock"],
   "tls": true,
   "tlscert": "${certs_dir}/server-cert.pem",
   "tlskey": "${certs_dir}/server-key.pem",

--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -36,9 +36,9 @@ stemcells:
 
 releases:
 - name: bpm
-  version: 1.1.8
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.8
-  sha1: c956394fce7e74f741e4ae8c256b480904ad5942
+  version: 1.1.19
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.19
+  sha1: 669baca975c6def518c7e736dbf189cfb438475b
 - name: haproxy
   version: 11.15.0
   url: https://github.com/cloudfoundry/haproxy-boshrelease/releases/download/v11.15.0/haproxy-11.15.0.tgz

--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -31,7 +31,7 @@ update:
 
 stemcells:
   - alias: default
-    os: ubuntu-bionic
+    os: ubuntu-jammy
     version: latest
 
 releases:

--- a/manifests/ops-files/no-backend.yml
+++ b/manifests/ops-files/no-backend.yml
@@ -1,0 +1,8 @@
+- type: remove
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties?/ha_proxy?/backend_port?
+- type: remove
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties?/ha_proxy?/backend_servers?
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties?/ha_proxy?/frontend_config?
+  value: |
+    http-request return status 200 content-type text/plain string OK


### PR DESCRIPTION
- Added convenience methods for local testing (docker socket, bosh env)
- Added ops-file for testing haproxy deploy w/o backend needed
- Bumped ssh client to deal with SHA1 no longer working as a signature algo
- Bumped BPM to v1.1.19 to fix logging issues on jammy
- Updated test for xenial to test for bionic (n-1 test)