### PR TITLE
Add Idle close on response option

### DIFF
--- a/acceptance-tests/bosh_helpers.go
+++ b/acceptance-tests/bosh_helpers.go
@@ -302,3 +302,8 @@ func drainHAProxy(haproxyInfo haproxyInfo) {
 	}()
 	time.Sleep(5 * time.Second)
 }
+
+func crashHAProxy(haproxyInfo haproxyInfo) {
+	_, _, err := runOnRemote(haproxyInfo.SSHUser, haproxyInfo.PublicIP, haproxyInfo.SSHPrivateKey, "sudo pkill -9 -x haproxy")
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/acceptance-tests/crash_test.go
+++ b/acceptance-tests/crash_test.go
@@ -1,0 +1,122 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Crash Test", func() {
+	opsfileDrainTimeout := `---
+# Enable health check
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/enable_health_check_http?
+  value: true
+# Enable draining
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/drain_enable?
+  value: true
+# Set grace period to 1s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/drain_frontend_grace_time?
+  value: 1
+# Set drain period to 1s
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/drain_timeout?
+  value: 1
+`
+	It("Restarts if terminated by a crash", func() {
+		haproxyBackendPort := 12000
+		// Expect initial deployment to be failing due to lack of healthy backends
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileDrainTimeout}, map[string]interface{}{}, false)
+
+		// Verify that is in a failing state
+		Expect(boshInstances(deploymentNameForTestNode())[0].ProcessState).To(Or(Equal("failing"), Equal("unresponsive agent")))
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+
+		By("Waiting monit to report HAProxy is now healthy (due to having a healthy backend instance)")
+		// Since the backend is now listening, HAProxy healthcheck should start returning healthy
+		// and monit should in turn start reporting a healthy process
+		// We will up to wait one minute for the status to stabilise
+		Eventually(func() string {
+			return boshInstances(deploymentNameForTestNode())[0].ProcessState
+		}, time.Minute, time.Second).Should(Equal("running"))
+
+		By("The healthcheck health endpoint should report a 200 status code")
+		expect200(http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP)))
+
+		By("Sending a request to HAProxy works")
+		expectTestServer200(http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP)))
+
+		By("Crash HAproxy - Sending a request to HAProxy fails")
+		crashHAProxy(haproxyInfo)
+		_, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+		expectConnectionRefusedErr(err)
+
+		By("Eventually, HAproxy comes back up again")
+		Eventually(func() error {
+			_, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+			return err
+		}, time.Minute, time.Second).Should(Not(HaveOccurred()))
+	})
+
+	It("Does not restart if terminated by draining", func() {
+		haproxyBackendPort := 12000
+		// Expect initial deployment to be failing due to lack of healthy backends
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileDrainTimeout}, map[string]interface{}{}, false)
+
+		// Verify that is in a failing state
+		Expect(boshInstances(deploymentNameForTestNode())[0].ProcessState).To(Or(Equal("failing"), Equal("unresponsive agent")))
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+
+		By("Waiting monit to report HAProxy is now healthy (due to having a healthy backend instance)")
+		// Since the backend is now listening, HAProxy healthcheck should start returning healthy
+		// and monit should in turn start reporting a healthy process
+		// We will up to wait one minute for the status to stabilise
+		Eventually(func() string {
+			return boshInstances(deploymentNameForTestNode())[0].ProcessState
+		}, time.Minute, time.Second).Should(Equal("running"))
+
+		By("The healthcheck health endpoint should report a 200 status code")
+		expect200(http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP)))
+
+		By("Sending a request to HAProxy works")
+		expectTestServer200(http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP)))
+
+		By("Drain HAproxy - Sending a request to HAProxy fails")
+		drainHAProxy(haproxyInfo)
+		Eventually(func() error {
+			_, err := net.Dial("tcp", fmt.Sprintf("%s:80", haproxyInfo.PublicIP))
+			return err
+		}, time.Minute, time.Second).Should(HaveOccurred())
+
+		By("Consistently, HAproxy does not come back up again")
+		Consistently(func() error {
+			_, err := net.Dial("tcp", fmt.Sprintf("%s:80", haproxyInfo.PublicIP))
+			return err
+		}, 30*time.Second, time.Second).Should(HaveOccurred())
+	})
+
+})

--- a/acceptance-tests/drain_test.go
+++ b/acceptance-tests/drain_test.go
@@ -76,12 +76,12 @@ var _ = Describe("Drain Test", func() {
 		time.Sleep(10 * time.Second)
 
 		By("After grace period has passed, draining should set in, disabling listeners")
-		// We need a new client so there won't be any reusable connections
-		httpClient := &http.Client{}
-		_, err = httpClient.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP))
+		_, err = http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP))
 		expectConnectionRefusedErr(err)
-		_, err = httpClient.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
-		expectConnectionRefusedErr(err)
+		Eventually(func() error {
+			_, err := net.Dial("tcp", fmt.Sprintf("%s:80", haproxyInfo.PublicIP))
+			return err
+		}, time.Minute, time.Second).Should(HaveOccurred())
 	})
 
 	// drain with a non-existent Process

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -176,6 +176,13 @@ properties:
       What to do if the external certificates list located at `ha_proxy.ext_crt_list_file` does not appear within the time
       denoted by `ha_proxy.ext_crt_list_timeout`. Set to either 'fail' (HAproxy will not start) or 'continue' (HAproxy will start without external certificates)
     default: "fail"
+  ha_proxy.reload_idle_close_on_response:
+    description: |
+      This option makes HAproxy wait for another request on idle connections during reloads or restarts. Once the response is received, a "Connection: close" header
+      is injected to signal to the client that this connection no longer usable and permitting a more graceful handling on the client's side. This has the downside
+      that HAproxy may linger around for longer, waiting for a request on idle connections, so it should be used in conjunction with the "reload_hard_stop_after" option
+      to limit that time. If set to false, idle connections will be terminated immediately during reloads or restarts.
+    default: true
   ha_proxy.reload_hard_stop_after:
     description: |
       Defines the maximum time allowed to perform a clean soft-stop. This is used when issuing a reload via the "bin/reload" script. It limits the time for the

--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -6,13 +6,21 @@ set -e
 pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
 sockfile=/var/vcap/sys/run/haproxy/stats.sock
 logfile=/var/vcap/sys/log/haproxy/drain.log
+lockfile=/var/vcap/sys/run/haproxy/drain.lock
+
+mkdir -p "$(dirname ${logfile})"
 
 <% if not p("ha_proxy.drain_enable") -%>
 echo "drain is disabled" >> ${logfile}
 echo 0
 exit 0
 <% else -%>
-mkdir -p "$(dirname ${logfile})"
+
+if [[ -f ${lockfile} ]]; then
+  echo "$(date): draining already in progress" >> ${logfile}
+  echo 0
+  exit 0
+fi
 
 if [[ ! -f ${pidfile} ]]; then
   echo "$(date): pidfile does not exist" >> ${logfile}
@@ -22,7 +30,7 @@ fi
 
 pid="$(cat ${pidfile})"
 if ! ps -p ${pid} >/dev/null; then
-  # In case haproxy_wrapper process is stale, pid_exists will be empty,
+  # In case haproxy_wrapper process is stale, pid will be empty,
   # the drain job should not fail
   echo "$(date): There was no process for the recorded haproxy_wrapper PID (${pid})." >> ${logfile}
   echo 0
@@ -39,12 +47,24 @@ haproxy_master_pid=$(pgrep -P "$pid" -x haproxy)
 <%- if p("ha_proxy.enable_health_check_http") -%>
 echo "disable frontend health_check_http_url" | /usr/local/bin/socat stdio unix-connect:${sockfile}
 echo "$(date): triggering grace period for process ${haproxy_master_pid}" >> ${logfile}
-sleep <%= p("ha_proxy.drain_frontend_grace_time") -%>
+sleep <%= p("ha_proxy.drain_frontend_grace_time") %>
 <%- end -%>
 
+touch ${lockfile}
 kill -USR1 "${haproxy_master_pid}"
 echo "$(date): triggering drain for process ${haproxy_master_pid}" >> ${logfile}
 
-echo <%= p("ha_proxy.drain_timeout") -%>
+drain_time=0
+drain_timeout=<%= p("ha_proxy.drain_timeout") %>
+while kill -0 "${haproxy_master_pid}" 2>/dev/null; do
+  sleep 1;
+  drain_time=$((drain_time + 1))
+  if [ $drain_time -eq $drain_timeout ]; then
+    echo "$(date): Process ${haproxy_master_pid} still alive after ${drain_timeout} seconds. Forcing stop." >> ${logfile}
+    break
+  fi
+done
+
+echo 0
 
 <%- end -%>

--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -59,7 +59,7 @@ drain_timeout=<%= p("ha_proxy.drain_timeout") %>
 while kill -0 "${haproxy_master_pid}" 2>/dev/null; do
   sleep 1;
   drain_time=$((drain_time + 1))
-  if [ $drain_time -eq $drain_timeout ]; then
+  if [ $drain_time -ge $drain_timeout ]; then
     echo "$(date): Process ${haproxy_master_pid} still alive after ${drain_timeout} seconds. Forcing stop." >> ${logfile}
     break
   fi

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -272,6 +272,9 @@ defaults
     option log-separate-errors
     maxconn <%= p("ha_proxy.max_connections") %>
     option http-server-close
+    <%- if_p("ha_proxy.reload_idle_close_on_response") do -%>
+    option idle-close-on-response
+    <%- end -%>
     option httplog
     option forwardfor
     option contstats

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -6,6 +6,7 @@ set -e
 export PATH=$PATH:/var/vcap/packages/haproxy/bin:/var/vcap/packages/ttar/bin
 CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
 PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
+lockfile=/var/vcap/sys/run/haproxy/drain.lock
 
 cleanup_daemon() {
   if [ -f ${PID_FILE} ]; then
@@ -106,7 +107,5 @@ trap reload_daemon USR2
 echo "$(date): Starting HAProxy"
 haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
 
-<%- if !run_in_foreground -%>
-# wait for the HAProxy main process to terminate
-while kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;
-<%- end -%>
+# wait for the HAProxy main process to terminate non-gracefully (drain)
+while [ -f ${lockfile} ] || kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -6,7 +6,7 @@ set -e
 export PATH=$PATH:/var/vcap/packages/haproxy/bin:/var/vcap/packages/ttar/bin
 CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
 PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
-lockfile=/var/vcap/sys/run/haproxy/drain.lock
+DRAIN_LOCK=/var/vcap/sys/run/haproxy/drain.lock
 
 cleanup_daemon() {
   if [ -f ${PID_FILE} ]; then
@@ -108,4 +108,4 @@ echo "$(date): Starting HAProxy"
 haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
 
 # wait for the HAProxy main process to terminate non-gracefully (drain)
-while [ -f ${lockfile} ] || kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;
+while [ -f ${DRAIN_LOCK} ] || kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;

--- a/spec/haproxy/templates/drain_spec.rb
+++ b/spec/haproxy/templates/drain_spec.rb
@@ -8,128 +8,58 @@ describe 'bin/drain' do
   describe 'ha_proxy.drain_enable' do
     context 'when enabled' do
       it 'includes drain logic' do
-        expect(template.render({
-          'ha_proxy' => {
-            'drain_enable' => true
+        drain = template.render(
+          {
+            'ha_proxy' => {
+              'drain_enable' => true
+            }
           }
-        })).to eq(<<~EXPECTED)
-          #!/bin/bash
-          # vim: set ft=sh
-
-          set -e
-
-          pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
-          sockfile=/var/vcap/sys/run/haproxy/stats.sock
-          logfile=/var/vcap/sys/log/haproxy/drain.log
-
-          mkdir -p "$(dirname ${logfile})"
-
-          if [[ ! -f ${pidfile} ]]; then
-            echo "$(date): pidfile does not exist" >> ${logfile}
-            echo 0
-            exit 0
-          fi
-
-          pid="$(cat ${pidfile})"
-          if ! ps -p ${pid} >/dev/null; then
-            # In case haproxy_wrapper process is stale, pid_exists will be empty,
-            # the drain job should not fail
-            echo "$(date): There was no process for the recorded haproxy_wrapper PID (${pid})." >> ${logfile}
-            echo 0
-            exit 0
-          fi
-
-          haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)
-          haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)
-
-
-          kill -USR1 "${haproxy_master_pid}"
-          echo "$(date): triggering drain for process ${haproxy_master_pid}" >> ${logfile}
-
-          echo 30
-        EXPECTED
+        )
+        expect(drain).not_to include('drain is disabled')
       end
 
       context 'when health checks are enabled' do
         it 'includes drain and grace logic' do
-          expect(template.render({
-            'ha_proxy' => {
-              'drain_enable' => true,
-              'enable_health_check_http' => true
+          drain = template.render(
+            {
+              'ha_proxy' => {
+                'drain_enable' => true,
+                'enable_health_check_http' => true
+              }
             }
-          })).to eq(<<~EXPECTED)
-            #!/bin/bash
-            # vim: set ft=sh
-
-            set -e
-
-            pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
-            sockfile=/var/vcap/sys/run/haproxy/stats.sock
-            logfile=/var/vcap/sys/log/haproxy/drain.log
-
-            mkdir -p "$(dirname ${logfile})"
-
-            if [[ ! -f ${pidfile} ]]; then
-              echo "$(date): pidfile does not exist" >> ${logfile}
-              echo 0
-              exit 0
-            fi
-
-            pid="$(cat ${pidfile})"
-            if ! ps -p ${pid} >/dev/null; then
-              # In case haproxy_wrapper process is stale, pid_exists will be empty,
-              # the drain job should not fail
-              echo "$(date): There was no process for the recorded haproxy_wrapper PID (${pid})." >> ${logfile}
-              echo 0
-              exit 0
-            fi
-
-            haproxy_wrapper_pid=$(pgrep -P "$pid" haproxy_wrapper)
-            haproxy_master_pid=$(pgrep -P "$haproxy_wrapper_pid" -x haproxy)
-
-            echo "disable frontend health_check_http_url" | /usr/local/bin/socat stdio unix-connect:${sockfile}
-            echo "$(date): triggering grace period for process ${haproxy_master_pid}" >> ${logfile}
-            sleep 0
-            kill -USR1 "${haproxy_master_pid}"
-            echo "$(date): triggering drain for process ${haproxy_master_pid}" >> ${logfile}
-
-            echo 30
-          EXPECTED
+          )
+          expect(drain).not_to include('drain is disabled')
+          expect(drain).to include('socat')
         end
       end
 
       context 'when a custom ha_proxy.drain_timeout is provided' do
         it 'overrides the default timeout' do
-          expect(template.render({
-            'ha_proxy' => {
-              'drain_enable' => true,
-              'drain_timeout' => 123
+          drain = template.render(
+            {
+              'ha_proxy' => {
+                'drain_enable' => true,
+                'drain_timeout' => 123
+              }
             }
-          }).split(/\n/).last).to eq('echo 123')
+          )
+          expect(drain).not_to include('drain is disabled')
+          expect(drain).to include('drain_timeout=123')
+          expect(drain).not_to include('socat')
         end
       end
     end
 
     context 'when disabled' do
       it 'does not include drain logic' do
-        expect(template.render({
-          'ha_proxy' => {
-            'drain_enable' => false
+        drain = template.render(
+          {
+            'ha_proxy' => {
+              'drain_enable' => false
+            }
           }
-        })).to eq(<<~EXPECTED)
-          #!/bin/bash
-          # vim: set ft=sh
-
-          set -e
-
-          pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
-          sockfile=/var/vcap/sys/run/haproxy/stats.sock
-          logfile=/var/vcap/sys/log/haproxy/drain.log
-
-          echo "drain is disabled" >> ${logfile}
-          echo 0
-          exit 0
-        EXPECTED
+        )
+        expect(drain).to include('drain is disabled')
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -24,6 +24,7 @@ describe 'config/haproxy.config global and default options' do
     expect(defaults).to include('option log-health-checks')
     expect(defaults).to include('option log-separate-errors')
     expect(defaults).to include('option http-server-close')
+    expect(defaults).to include('option idle-close-on-response')
     expect(defaults).to include('option httplog')
     expect(defaults).to include('option forwardfor')
     expect(defaults).to include('option contstats')


### PR DESCRIPTION
This should prevent idle connections from being terminated immediately during restarts/reloads.

The default is to enable to option as this used to be the default behavior prior to 2.4 and was changed silently.

We also have a default value for hard-stop-after so enabling the option by default should be safe.

Changes:

- idle-close-on-response enabled by default (HAproxy will gracefully close idle conns now, instead of closing them outright)
- draining will no longer cause HAproxy to be restarted by monit after it has terminated itself
- the draining process is now handled completely within the drain script. BOSH wait time is set to 0.
- HAproxy will still be restarted after crashes unrelated to draining
- made the unit tests for the drain script less strict and error-prone