### PR TITLE
Canned Bosh Director for Acceptance Tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,6 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
-  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -17,6 +17,13 @@
 cd ci/new
 ./build-canned-docker.sh
 ```
+
+Re-build the `haproxy-boshrelease-testflight` image:
+```shell
+cd `ci/`
+docker build --no-cache -t haproxy-boshrelease-testflight .
+```
+
 ### Running tests locally
 
 ```shell

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -11,10 +11,39 @@
   * Get it from https://bosh.io/releases/github.com/cloudfoundry/bpm-release?all=1
 
 ## Running
+### Building canned docker image
 
 ```shell
-cd acceptance-tests
-./run-local.sh
+cd ci/new
+./build-canned-docker.sh
+```
+### Running tests locally
+
+```shell
+docker run -d --privileged -v "$REPO_DIR":/repo -e REPO_ROOT=/repo haproxy-boshrelease-testflight bash -c "sleep infinity "
+```
+If you're sure you have only one running docker container:
+
+```shell
+docker exec -it $(docker ps -q -l) bash -l
+```
+
+Otherwise, get the ID of your container:
+
+```shell
+docker ps
+```
+
+Then, run 
+```shell
+docker exec -it $(docker ps -q -l) bash -l
+```
+
+Once connected to the container, run:
+
+```shell
+cd ci/scripts
+./acceptance-tests
 ```
 
 ### Running on Docker for Mac

--- a/acceptance-tests/run-local.sh
+++ b/acceptance-tests/run-local.sh
@@ -5,13 +5,6 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")/" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# if [ "$(git status -s | wc -l)" -gt 0 ]; then
-#     echo "You have changes in your Git repository. Commit or clean (e.g. git clean -f) before running."
-#     echo "The build will fail otherwise."
-#     echo "Git Status:"
-#     git status
-#     exit 1
-# fi
 
 FOCUS="$1"
 

--- a/acceptance-tests/run-local.sh
+++ b/acceptance-tests/run-local.sh
@@ -5,13 +5,13 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")/" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-if [ "$(git status -s | wc -l)" -gt 0 ]; then
-    echo "You have changes in your Git repository. Commit or clean (e.g. git clean -f) before running."
-    echo "The build will fail otherwise."
-    echo "Git Status:"
-    git status
-    exit 1
-fi
+# if [ "$(git status -s | wc -l)" -gt 0 ]; then
+#     echo "You have changes in your Git repository. Commit or clean (e.g. git clean -f) before running."
+#     echo "The build will fail otherwise."
+#     echo "Git Status:"
+#     git status
+#     exit 1
+# fi
 
 FOCUS="$1"
 
@@ -35,7 +35,7 @@ fi
 
 # Build acceptance test image
 pushd "$SCRIPT_DIR/../ci" || exit 1
- docker build -t haproxy-boshrelease-testflight .
+ docker build --no-cache -t haproxy-boshrelease-testflight .
 popd || exit 1
 
 # Run acceptance tests

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,23 +1,16 @@
 FROM ${BOSH_DIRECTOR_TAG:-bosh-director-docker}
 
-ARG GINKGO_VERSION=v2.2.0
-
-ENV DEBIAN_FRONTEND=noninteractive
+ARG GINKGO_VERSION="v2.2.0"
 
 # Install all necessary tools for haproxy testflight and dependency autobump
-RUN apt-get update && apt-get install -y wget jq git vim nano python3-pip\
-  && wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | apt-key add - \
-  && echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list \
-  && apt-get update && apt-get install -y wget spruce && apt-get clean
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl wget jq git vim python3-pip
 
-# Add go to path
-RUN echo "export PATH=\$PATH:\$GOPATH/bin" >> /root/.bashrc
+# install go tooling
+ENV GOBIN=/usr/local/bin
+RUN go install github.com/geofffranks/spruce/cmd/spruce@latest && \
+    go install "github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}"
 
 # Install Python libraries needed for scripts
 COPY scripts/requirements.txt /requirements.txt
-
 RUN /usr/bin/python3 -m pip install -r /requirements.txt
-
-ENV GOPATH=/go
-RUN mkdir /go
-RUN go install "github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM bosh/main-bosh-docker
+FROM ${BOSH_DIRECTOR_TAG:-bosh-director-docker}
 
 ARG GINKGO_VERSION=v2.2.0
 
@@ -10,13 +10,12 @@ RUN apt-get update && apt-get install -y wget jq git vim nano python3-pip\
   && echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list \
   && apt-get update && apt-get install -y wget spruce && apt-get clean
 
-# Set bosh env at login
-RUN echo "source /tmp/local-bosh/director/env" >> /root/.bashrc
 # Add go to path
 RUN echo "export PATH=\$PATH:\$GOPATH/bin" >> /root/.bashrc
 
 # Install Python libraries needed for scripts
 COPY scripts/requirements.txt /requirements.txt
+
 RUN /usr/bin/python3 -m pip install -r /requirements.txt
 
 ENV GOPATH=/go

--- a/ci/new/build-canned-docker.sh
+++ b/ci/new/build-canned-docker.sh
@@ -3,7 +3,7 @@
 BUILD_CONTAINER=bosh-director-build-$(date +%s)-$RANDOM
 
 BOSH_DIRECTOR_TAG=${1:-bosh-director-docker}
-BASE_IMAGE=${2:-bosh/docker-cpi:main}
+BASE_IMAGE=${2:-bosh/main-bosh-docker}
 
 docker run -d -e BOSH_CERT_DIR=/tmp/certs --privileged --name "$BUILD_CONTAINER" "$BASE_IMAGE" sleep infinity
 

--- a/ci/new/build-canned-docker.sh
+++ b/ci/new/build-canned-docker.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+BUILD_CONTAINER=bosh-director-build-$(date +%s)-$RANDOM
+
+docker run -d -e BOSH_CERT_DIR=/tmp/certs --privileged --name $BUILD_CONTAINER bosh/docker-cpi:main sleep infinity
+
+docker exec -e BOSH_CERT_DIR=/tmp/certs $BUILD_CONTAINER bash -c '
+    sed -i '"'"'s#certs_dir=$(mktemp -d)#certs_dir=${BOSH_CERT_DIR:-$(mktemp -d /tmp/certs.XXXX)}#'"'"' $(command -v start-bosh)
+
+    [ -n "$BOSH_CERT_DIR" ] && mkdir -p $BOSH_CERT_DIR
+    
+    # disable automatically calling the bosh director creation, just register the functions.
+    sed -i "/main .*\$/d" $(command -v start-bosh)
+    source start-bosh
+
+    # run the code in start-bosh
+    main
+
+    echo "source /tmp/local-bosh/director/env" >> /etc/profile
+
+    export BOSH0_CONTAINER=$(jq .current_vm_cid -r /tmp/local-bosh/director/state.json)
+
+    docker exec "$BOSH0_CONTAINER" bash -c "
+        /var/vcap/bosh/bin/monit stop all
+        
+        while ! ( /var/vcap/bosh/bin/monit summary | grep -E '"'"'System.*not monitored$'"'"' ); do echo Waiting for monit to stop all jobs; sleep 1; done
+
+        echo Redirecting the volume for /var/vcap/store to the mounted BOSH volume
+        umount -f /var/vcap/store
+        rm -rf /var/vcap/store; ln -nfs /warden-cpi-dev/vol-* /var/vcap/store
+    "
+
+    # remove folders that tie the docker engine to this container
+    rm -rf /scratch/docker/tmp /scratch/docker/runtimes
+'
+
+docker stop "$BUILD_CONTAINER"
+
+docker tag $(docker commit "$BUILD_CONTAINER") bosh-director-docker 
+
+docker rm -f "$BUILD_CONTAINER"
+
+docker run -d --privileged --name canned-bosh bosh-director-docker
+
+docker exec -t -e BOSH_CERT_DIR=/tmp/certs canned-bosh bash -l -c '
+    source start-bosh
+    generate_certs $BOSH_CERT_DIR
+
+    echo '"'"'export OUTER_CONTAINER_IP=$(ip route get 8.8.8.8 | head -n1 | cut -d " " -f 8)'"'"' >> /etc/profile
+    echo '"'"'export DOCKER_HOST=tcp://$OUTER_CONTAINER_IP:4243'"'"' >> /etc/profile
+    echo "export DOCKER_TLS_VERIFY=1" >> /etc/profile
+    echo "export DOCKER_CERT_PATH=$BOSH_CERT_DIR" >> /etc/profile
+
+    source /etc/profile
+
+    service docker start || echo "Failed to start Docker!"
+
+    while ! docker ps > /dev/null; do echo "Waiting for Docker to start"; sleep 1; done;
+
+    export BOSH0_CONTAINER=$(jq .current_vm_cid -r /tmp/local-bosh/director/state.json)
+
+    docker start "$BOSH0_CONTAINER"
+
+    while [ "$(docker container ls -a --format "{{json .State}}" --filter name=$BOSH0_CONTAINER | jq . -r)" != "running" ]; do echo Waiting for bosh/0 container to start; sleep 1; done;
+
+    docker exec "$BOSH0_CONTAINER" /var/vcap/bosh/bin/monit start all
+    docker exec "$BOSH0_CONTAINER" bash -c "while ! ( /var/vcap/bosh/bin/monit summary | grep -E '"'"'System.*running$'"'"' ); do echo Waiting for monit to start all jobs; sleep 1; done"
+    bosh env
+'

--- a/ci/new/build-canned-docker.sh
+++ b/ci/new/build-canned-docker.sh
@@ -2,7 +2,10 @@
 
 BUILD_CONTAINER=bosh-director-build-$(date +%s)-$RANDOM
 
-docker run -d -e BOSH_CERT_DIR=/tmp/certs --privileged --name $BUILD_CONTAINER bosh/docker-cpi:main sleep infinity
+BOSH_DIRECTOR_TAG=${1:-bosh-director-docker}
+BASE_IMAGE=${2:-bosh/docker-cpi:main}
+
+docker run -d -e BOSH_CERT_DIR=/tmp/certs --privileged --name "$BUILD_CONTAINER" "$BASE_IMAGE" sleep infinity
 
 docker exec -e BOSH_CERT_DIR=/tmp/certs $BUILD_CONTAINER bash -c '
     sed -i '"'"'s#certs_dir=$(mktemp -d)#certs_dir=${BOSH_CERT_DIR:-$(mktemp -d /tmp/certs.XXXX)}#'"'"' $(command -v start-bosh)
@@ -36,34 +39,6 @@ docker exec -e BOSH_CERT_DIR=/tmp/certs $BUILD_CONTAINER bash -c '
 
 docker stop "$BUILD_CONTAINER"
 
-docker tag $(docker commit "$BUILD_CONTAINER") bosh-director-docker 
+docker tag $(docker commit "$BUILD_CONTAINER") "$BOSH_DIRECTOR_TAG"
 
 docker rm -f "$BUILD_CONTAINER"
-
-docker run -d --privileged --name canned-bosh bosh-director-docker
-
-docker exec -t -e BOSH_CERT_DIR=/tmp/certs canned-bosh bash -l -c '
-    source start-bosh
-    generate_certs $BOSH_CERT_DIR
-
-    echo '"'"'export OUTER_CONTAINER_IP=$(ip route get 8.8.8.8 | head -n1 | cut -d " " -f 8)'"'"' >> /etc/profile
-    echo '"'"'export DOCKER_HOST=tcp://$OUTER_CONTAINER_IP:4243'"'"' >> /etc/profile
-    echo "export DOCKER_TLS_VERIFY=1" >> /etc/profile
-    echo "export DOCKER_CERT_PATH=$BOSH_CERT_DIR" >> /etc/profile
-
-    source /etc/profile
-
-    service docker start || echo "Failed to start Docker!"
-
-    while ! docker ps > /dev/null; do echo "Waiting for Docker to start"; sleep 1; done;
-
-    export BOSH0_CONTAINER=$(jq .current_vm_cid -r /tmp/local-bosh/director/state.json)
-
-    docker start "$BOSH0_CONTAINER"
-
-    while [ "$(docker container ls -a --format "{{json .State}}" --filter name=$BOSH0_CONTAINER | jq . -r)" != "running" ]; do echo Waiting for bosh/0 container to start; sleep 1; done;
-
-    docker exec "$BOSH0_CONTAINER" /var/vcap/bosh/bin/monit start all
-    docker exec "$BOSH0_CONTAINER" bash -c "while ! ( /var/vcap/bosh/bin/monit summary | grep -E '"'"'System.*running$'"'"' ); do echo Waiting for monit to start all jobs; sleep 1; done"
-    bosh env
-'

--- a/ci/new/build-canned-docker.sh
+++ b/ci/new/build-canned-docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 BUILD_CONTAINER=bosh-director-build-$(date +%s)-$RANDOM
 
 BOSH_DIRECTOR_TAG=${1:-bosh-director-docker}
@@ -8,6 +10,7 @@ BASE_IMAGE=${2:-bosh/main-bosh-docker}
 docker run -d -e BOSH_CERT_DIR=/tmp/certs --privileged --name "$BUILD_CONTAINER" "$BASE_IMAGE" sleep infinity
 
 docker exec -e BOSH_CERT_DIR=/tmp/certs $BUILD_CONTAINER bash -c '
+    set -x
     sed -i '"'"'s#certs_dir=$(mktemp -d)#certs_dir=${BOSH_CERT_DIR:-$(mktemp -d /tmp/certs.XXXX)}#'"'"' $(command -v start-bosh)
 
     [ -n "$BOSH_CERT_DIR" ] && mkdir -p $BOSH_CERT_DIR
@@ -24,6 +27,7 @@ docker exec -e BOSH_CERT_DIR=/tmp/certs $BUILD_CONTAINER bash -c '
     export BOSH0_CONTAINER=$(jq .current_vm_cid -r /tmp/local-bosh/director/state.json)
 
     docker exec "$BOSH0_CONTAINER" bash -c "
+        set -x
         /var/vcap/bosh/bin/monit stop all
         
         while ! ( /var/vcap/bosh/bin/monit summary | grep -E '"'"'System.*not monitored$'"'"' ); do echo Waiting for monit to stop all jobs; sleep 1; done

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -14,7 +14,7 @@ if [ -n "$FOCUS" ]; then
   FOCUS_ARG="-focus $FOCUS"
 fi
 
-cd ${REPO_ROOT:?required}
+cd "${REPO_ROOT:?required}"
 echo "----- Pulling in any git submodules..."
 git submodule update --init --recursive --force
 
@@ -35,14 +35,12 @@ fi
 
 echo "----- Creating candidate BOSH release..."
 bosh -n reset-release # in case dev_releases/ is in repo accidentally
-
 time bosh create-release --force
 
-echo "uploading release. Vars:"
-env
 bosh upload-release --rebase
 release_final_version=$(spruce json dev_releases/*/index.yml | jq -r ".builds[].version" | sed -e "s%+.*%%")
 export RELEASE_VERSION="${release_final_version}.latest"
+echo
 echo "----- Created ${RELEASE_VERSION}"
 
 echo "----- Uploading Jammy stemcell"

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -39,7 +39,7 @@ bosh -n reset-release # in case dev_releases/ is in repo accidentally
 time bosh create-release --force
 
 echo "uploading release. Vars:"
-export
+env
 bosh upload-release --rebase
 release_final_version=$(spruce json dev_releases/*/index.yml | jq -r ".builds[].version" | sed -e "s%+.*%%")
 export RELEASE_VERSION="${release_final_version}.latest"

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -20,7 +20,9 @@ git submodule update --init --recursive --force
 
 echo "----- Starting BOSH"
 
-./ci/scripts/start-bosh.sh
+time ./ci/scripts/start-bosh.sh || ( echo Starting bosh failed! && exit 1 )
+
+source /tmp/local-bosh/director/env
 
 function stop_docker() {
   echo "----- stopping docker"
@@ -31,26 +33,28 @@ if [ -z "$FOCUS" ]; then
   trap stop_docker EXIT
 fi
 
-source /tmp/local-bosh/director/env
-
 echo "----- Creating candidate BOSH release..."
 bosh -n reset-release # in case dev_releases/ is in repo accidentally
 
-bosh create-release
+time bosh create-release
+
+echo "uploading release. Vars:"
+export
 bosh upload-release --rebase
 release_final_version=$(spruce json dev_releases/*/index.yml | jq -r ".builds[].version" | sed -e "s%+.*%%")
 export RELEASE_VERSION="${release_final_version}.latest"
 echo "----- Created ${RELEASE_VERSION}"
 
 echo "----- Uploading Jammy stemcell"
-bosh -n upload-stemcell $stemcell_jammy_path
+time bosh -n upload-stemcell $stemcell_jammy_path
 
 echo "----- Uploading Bionic stemcell"
-bosh -n upload-stemcell $stemcell_bionic_path
+time bosh -n upload-stemcell $stemcell_bionic_path
 
 echo "----- Uploading BPM"
 bosh -n upload-release $bpm_release_path
 
+# TODO: Do we need to autobump this?
 echo "----- Uploading os-conf (used for tests only)"
 bosh -n upload-release --sha1 386293038ae3d00813eaa475b4acf63f8da226ef \
   https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.2

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -18,25 +18,25 @@ cd ${REPO_ROOT:?required}
 echo "----- Pulling in any git submodules..."
 git submodule update --init --recursive --force
 
-echo "----- Starting BOSH"
-
-time ./ci/scripts/start-bosh.sh || ( echo Starting bosh failed! && exit 1 )
-
-source /tmp/local-bosh/director/env
+if ! timeout 1 bosh env &>/dev/null; then
+  echo "----- Starting BOSH"
+  time ./ci/scripts/start-bosh.sh || ( echo Starting bosh failed! && exit 1 )
+  source /tmp/local-bosh/director/env
+fi
 
 function stop_docker() {
   echo "----- stopping docker"
   service docker stop
 }
 
-if [ -z "$FOCUS" ]; then
+if [ -z "$FOCUS" ] && [ -z "$NO_STOP" ]; then
   trap stop_docker EXIT
 fi
 
 echo "----- Creating candidate BOSH release..."
 bosh -n reset-release # in case dev_releases/ is in repo accidentally
 
-time bosh create-release
+time bosh create-release --force
 
 echo "uploading release. Vars:"
 export

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -49,6 +49,7 @@ done
 docker exec "$BOSH0_CONTAINER" /var/vcap/bosh/bin/monit start all
 docker exec "$BOSH0_CONTAINER" bash -c 'while ! ( /var/vcap/bosh/bin/monit summary | grep -E "System.*running\$" ); do echo Waiting for monit to start all jobs; sleep 1; done'
 docker exec "$BOSH0_CONTAINER" bash -c 'if ! ( /var/vcap/bosh/bin/monit summary | grep -w nats | grep running ); then echo "nats not running"; pkill nats-server; /var/vcap/bosh/bin/monit restart all ; fi '
+docker exec "$BOSH0_CONTAINER" bash -c 'while ! ( /var/vcap/bosh/bin/monit summary | grep -E "System.*running\$" ); do echo Waiting for monit to start all jobs; sleep 1; done'
 
 while ! bosh env &>/dev/null; do
   echo "Waiting for BOSH Director to respond"

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -48,6 +48,7 @@ done
 
 docker exec "$BOSH0_CONTAINER" /var/vcap/bosh/bin/monit start all
 docker exec "$BOSH0_CONTAINER" bash -c 'while ! ( /var/vcap/bosh/bin/monit summary | grep -E "System.*running\$" ); do echo Waiting for monit to start all jobs; sleep 1; done'
+docker exec "$BOSH0_CONTAINER" bash -c 'if ! ( /var/vcap/bosh/bin/monit summary | grep -w nats | grep running ); then echo "nats not running"; pkill nats-server; /var/vcap/bosh/bin/monit restart all ; fi '
 
 while ! bosh env &>/dev/null; do
   echo "Waiting for BOSH Director to respond"

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -13,25 +13,33 @@ source /tmp/local-bosh/director/env
 
 export
 
-service docker start || ( echo "Failed to start Docker!"
-  echo --- docker log ---
-  tail -n 50 /var/log/docker.log
-  echo --- / docker log ---
-  exit 1
-)
+if ! docker ps &>/dev/null; then
+  service docker start || ( echo "Failed to start Docker!"
+    echo --- docker log ---
+    tail -n 50 /var/log/docker.log
+    echo --- / docker log ---
+    exit 1
+  )
+fi
 
+docker_retries=10
 while ! docker ps &>/dev/null; do 
   echo "Waiting for Docker to start"
   sleep 1
+  docker_retries=$(($docker_retries - 1))
+  if [ $docker_retries -eq 0 ]; then
+    echo "Starting Docker failed"
+    echo --- docker log ---
+    tail -n 20 /var/log/docker.log
+    echo --- / docker log ---
+    exit 1
+  fi
 done
 
-echo --- docker log ---
-tail -n 50 /var/log/docker.log
-echo --- / docker log ---
 
 export BOSH0_CONTAINER=$(jq .current_vm_cid -r /tmp/local-bosh/director/state.json)
 
-docker start "$BOSH0_CONTAINER"
+docker start "$BOSH0_CONTAINER" || (echo could not start bosh/0 && exit 1)
 
 while [ "$(docker container ls -a --format "{{json .State}}" --filter name=$BOSH0_CONTAINER | jq . -r)" != "running" ]; do 
   echo "Waiting for bosh/0 container to start"

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -1,225 +1,48 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -e
+source start-bosh
+generate_certs $BOSH_CERT_DIR
 
-function generate_certs() {
-  local certs_dir
-  certs_dir="${1}"
+echo 'export OUTER_CONTAINER_IP=$(ip route get 8.8.8.8 | head -n1 | cut -d " " -f 7)' >> /tmp/local-bosh/director/env
+echo 'export DOCKER_HOST=tcp://$OUTER_CONTAINER_IP:4243' >> /tmp/local-bosh/director/env
+echo "export DOCKER_TLS_VERIFY=1" >> /tmp/local-bosh/director/env
+echo "export DOCKER_CERT_PATH=$BOSH_CERT_DIR" >> /tmp/local-bosh/director/env
 
-  pushd "${certs_dir}"
+source /tmp/local-bosh/director/env
 
-    jq -ner --arg "ip" "${OUTER_CONTAINER_IP}" '{
-      "variables": [
-        {
-          "name": "docker_ca",
-          "type": "certificate",
-          "options": {
-            "is_ca": true,
-            "common_name": "ca"
-          }
-        },
-        {
-          "name": "docker_tls",
-          "type": "certificate",
-          "options": {
-            "extended_key_usage": [
-              "server_auth"
-            ],
-            "common_name": $ip,
-            "alternative_names": [ $ip ],
-            "ca": "docker_ca"
-          }
-        },
-        {
-          "name": "client_docker_tls",
-          "type": "certificate",
-          "options": {
-            "extended_key_usage": [
-              "client_auth"
-            ],
-            "common_name": $ip,
-            "alternative_names": [ $ip ],
-            "ca": "docker_ca"
-          }
-        }
-      ]
-    }' > ./bosh-vars.yml
+export
 
-   bosh int ./bosh-vars.yml --vars-store=./certs.yml
-   bosh int ./certs.yml --path=/docker_ca/ca > ./ca.pem
-   bosh int ./certs.yml --path=/docker_tls/certificate > ./server-cert.pem
-   bosh int ./certs.yml --path=/docker_tls/private_key > ./server-key.pem
-   bosh int ./certs.yml --path=/client_docker_tls/certificate > ./cert.pem
-   bosh int ./certs.yml --path=/client_docker_tls/private_key > ./key.pem
-    # generate certs in json format
-    #
-   ruby -e 'puts File.read("./ca.pem").split("\n").join("\\n")' > "$certs_dir/ca_json_safe.pem"
-   ruby -e 'puts File.read("./cert.pem").split("\n").join("\\n")' > "$certs_dir/client_certificate_json_safe.pem"
-   ruby -e 'puts File.read("./key.pem").split("\n").join("\\n")' > "$certs_dir/client_private_key_json_safe.pem"
-  popd
-}
+service docker start || ( echo "Failed to start Docker!"
+  echo --- docker log ---
+  tail -n 50 /var/log/docker.log
+  echo --- / docker log ---
+  exit 1
+)
 
-function sanitize_cgroups() {
-  mkdir -p /sys/fs/cgroup
-  mountpoint -q /sys/fs/cgroup || \
-    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+while ! docker ps &>/dev/null; do 
+  echo "Waiting for Docker to start"
+  sleep 1
+done
 
-  mount -o remount,rw /sys/fs/cgroup
+echo --- docker log ---
+tail -n 50 /var/log/docker.log
+echo --- / docker log ---
 
-  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
-    if [ "$enabled" != "1" ]; then
-      # subsystem disabled; skip
-      continue
-    fi
+export BOSH0_CONTAINER=$(jq .current_vm_cid -r /tmp/local-bosh/director/state.json)
 
-    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")"
-    if [ -z "$grouping" ]; then
-      # subsystem not mounted anywhere; mount it on its own
-      grouping="$sys"
-    fi
+docker start "$BOSH0_CONTAINER"
 
-    mountpoint="/sys/fs/cgroup/$grouping"
+while [ "$(docker container ls -a --format "{{json .State}}" --filter name=$BOSH0_CONTAINER | jq . -r)" != "running" ]; do 
+  echo "Waiting for bosh/0 container to start"
+  sleep 1
+done
 
-    mkdir -p "$mountpoint"
+docker exec "$BOSH0_CONTAINER" /var/vcap/bosh/bin/monit start all
+docker exec "$BOSH0_CONTAINER" bash -c 'while ! ( /var/vcap/bosh/bin/monit summary | grep -E "System.*running\$" ); do echo Waiting for monit to start all jobs; sleep 1; done'
 
-    # clear out existing mount to make sure new one is read-write
-    if mountpoint -q "$mountpoint"; then
-      umount "$mountpoint"
-    fi
-
-    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
-
-    if [ "$grouping" != "$sys" ]; then
-      if [ -L "/sys/fs/cgroup/$sys" ]; then
-        rm "/sys/fs/cgroup/$sys"
-      fi
-
-      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
-    fi
-  done
-}
-
-function stop_docker() {
-  echo "ERROR: stopping docker"
-  service docker stop
-}
-
-function start_docker() {
-  generate_certs "$1"
-  local mtu
-  mkdir -p /var/log
-  mkdir -p /var/run
-
-  sanitize_cgroups
-
-  # ensure systemd cgroup is present
-  mkdir -p /sys/fs/cgroup/systemd
-  if ! mountpoint -q /sys/fs/cgroup/systemd ; then
-    mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
-  fi
-
-  # check for /proc/sys being mounted readonly, as systemd does
-  if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
-    mount -o remount,rw /proc/sys
-  fi
-
-  mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
-
-  [[ ! -d /etc/docker ]] && mkdir /etc/docker
-  cat <<EOF > /etc/docker/daemon.json
-{
-  "hosts": ["${DOCKER_HOST}","unix:///var/run/docker.sock"],
-  "tls": true,
-  "tlscert": "${certs_dir}/server-cert.pem",
-  "tlskey": "${certs_dir}/server-key.pem",
-  "tlscacert": "${certs_dir}/ca.pem",
-  "mtu": ${mtu},
-  "data-root": "/scratch/docker",
-  "tlsverify": true
-}
-EOF
-
-  trap stop_docker ERR
-  service docker start
-
-  export DOCKER_TLS_VERIFY=1
-  export DOCKER_CERT_PATH=$1
-
-  rc=1
-  for i in $(seq 1 100); do
-    echo waiting for docker to come up...
-    sleep 1
-    set +e
-    docker info
-    rc=$?
-    set -e
-    if [ "$rc" -eq "0" ]; then
-        break
-    fi
-  done
-
-  if [ "$rc" -ne "0" ]; then
-    exit 1
-  fi
-
-  echo $certs_dir
-}
-
-function main() {
-  export OUTER_CONTAINER_IP=$(ruby -rsocket -e 'puts Socket.ip_address_list
-                          .reject { |addr| !addr.ip? || addr.ipv4_loopback? || addr.ipv6? }
-                          .map { |addr| addr.ip_address }.first')
-
-  export DOCKER_HOST="tcp://${OUTER_CONTAINER_IP}:4243"
-
-  local certs_dir
-  certs_dir=$(mktemp -d)
-  start_docker "${certs_dir}"
-
-  local local_bosh_dir
-  local_bosh_dir="/tmp/local-bosh/director"
-
-  if ! docker network ls | grep director_network; then
-    docker network create -d bridge --subnet=10.245.0.0/16 director_network
-  fi
-
-  pushd ${BOSH_DEPLOYMENT_PATH:-/usr/local/bosh-deployment} > /dev/null
-      export BOSH_DIRECTOR_IP="10.245.0.3"
-      export BOSH_ENVIRONMENT="docker-director"
-
-      mkdir -p ${local_bosh_dir}
-
-      command bosh int bosh.yml \
-        -o docker/cpi.yml \
-        -o jumpbox-user.yml \
-        -v director_name=docker \
-        -v internal_cidr=10.245.0.0/16 \
-        -v internal_gw=10.245.0.1 \
-        -v internal_ip="${BOSH_DIRECTOR_IP}" \
-        -v docker_host="${DOCKER_HOST}" \
-        -v network=director_network \
-        -v docker_tls="{\"ca\": \"$(cat ${certs_dir}/ca_json_safe.pem)\",\"certificate\": \"$(cat ${certs_dir}/client_certificate_json_safe.pem)\",\"private_key\": \"$(cat ${certs_dir}/client_private_key_json_safe.pem)\"}" \
-        ${@} > "${local_bosh_dir}/bosh-director.yml"
-
-      command bosh create-env "${local_bosh_dir}/bosh-director.yml" \
-              --vars-store="${local_bosh_dir}/creds.yml" \
-              --state="${local_bosh_dir}/state.json"
-
-      bosh int "${local_bosh_dir}/creds.yml" --path /director_ssl/ca > "${local_bosh_dir}/ca.crt"
-      bosh -e "${BOSH_DIRECTOR_IP}" --ca-cert "${local_bosh_dir}/ca.crt" alias-env "${BOSH_ENVIRONMENT}"
-
-      cat <<EOF > "${local_bosh_dir}/env"
-      export BOSH_ENVIRONMENT="${BOSH_ENVIRONMENT}"
-      export BOSH_CLIENT=admin
-      export BOSH_CLIENT_SECRET=`bosh int "${local_bosh_dir}/creds.yml" --path /admin_password`
-      export BOSH_CA_CERT="${local_bosh_dir}/ca.crt"
-
-EOF
-      source "${local_bosh_dir}/env"
-
-      bosh -n update-cloud-config docker/cloud-config.yml -v network=director_network
-
-  popd > /dev/null
-}
-
-main $@
+while ! bosh env &>/dev/null; do
+  echo "Waiting for BOSH Director to respond"
+  sleep 1
+done
+bosh env


### PR DESCRIPTION
Add script for creating a running bosh director in Docker that can be resurrected.

This is for running locally only so far.
Integration with the concourse pipeline will be done in a future activity.