### PR TITLE
Close connection on health checks

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -309,6 +309,7 @@ listen stats
 listen health_check_http_url
     bind :<%= p("ha_proxy.health_check_port") %>
     mode http
+    option httpclose
     monitor-uri /health
     acl http-routers_down nbsrv(<%= backends.first[:name] %>) eq 0
     monitor fail if http-routers_down

--- a/spec/haproxy/templates/haproxy_config/healthcheck_listener_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/healthcheck_listener_spec.rb
@@ -19,6 +19,7 @@ describe 'config/haproxy.config healthcheck listeners' do
     it 'adds a health check listener for the http-routers-http1' do
       expect(healthcheck_listener).to include('bind :8080')
       expect(healthcheck_listener).to include('mode http')
+      expect(healthcheck_listener).to include('option httpclose')
       expect(healthcheck_listener).to include('monitor-uri /health')
       expect(healthcheck_listener).to include('acl http-routers_down nbsrv(http-routers-http1) eq 0')
       expect(healthcheck_listener).to include('monitor fail if http-routers_down')
@@ -38,6 +39,7 @@ describe 'config/haproxy.config healthcheck listeners' do
       it 'adds a health check listener for the http-routers-http2' do
         expect(healthcheck_listener).to include('bind :8080')
         expect(healthcheck_listener).to include('mode http')
+        expect(healthcheck_listener).to include('option httpclose')
         expect(healthcheck_listener).to include('monitor-uri /health')
         expect(healthcheck_listener).to include('acl http-routers_down nbsrv(http-routers-http2) eq 0')
         expect(healthcheck_listener).to include('monitor fail if http-routers_down')


### PR DESCRIPTION
This PR fixes a bug with the Azure load balancer that prevents it from recognizing this HAproxy instance as unhealthy during draining.
The setting forces a "connection: close" from HAproxy as well as a FIN sent to the client. This forces the load balancer to open a new connection on every health check, which won't be possible during draining, because the listener will have been disabled by then.
The result is that the Azure load balancer immediately acknowledges this HAproxy as unhealthy and will stop sending new connections to it.