### PR TITLE
Bump haproxy version to 2.6.7

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.6.6.tar.gz:
-  size: 4015438
-  object_id: a8f6e515-9d48-4591-7892-5cf10dadbdd0
-  sha: sha256:d0c80c90c04ae79598b58b9749d53787f00f7b515175e7d8203f2796e6a6594d
+haproxy/haproxy-2.6.7.tar.gz:
+  size: 4028355
+  object_id: 0889d657-c2c6-4c2d-4b3d-ba36bb16117d
+  sha: sha256:cff9b8b18a52bfec277f9c1887fac93c18e1b9f3eff48892255a7c6e64528b7d
 haproxy/hatop-0.8.2.tar.gz:
   size: 138030
   object_id: eca866ad-3c8f-4526-51d1-23179c1bbda8

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.40  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.6.6  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.6.tar.gz
+HAPROXY_VERSION=2.6.7  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.7.tar.gz
 
 HATOP_VERSION=0.8.2  # https://api.github.com/repos/jhunt/hatop/tarball/v0.8.2
 


### PR DESCRIPTION

Automatic bump from version 2.6.6 to version 2.6.7, downloaded from https://www.haproxy.org/download/2.6/src/haproxy-2.6.7.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
