### PR TITLE
Bump pcre2 version to 10.41

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,10 @@ haproxy/lua-5.4.4.tar.gz:
   size: 360876
   object_id: 5b2652c4-3c00-4d2d-742d-dda229e95bac
   sha: sha256:164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61
-haproxy/pcre2-10.40.tar.gz:
-  size: 2359622
-  object_id: 3a0e0202-481e-4df9-63fe-7080a130223e
-  sha: sha256:ded42661cab30ada2e72ebff9e725e745b4b16ce831993635136f2ef86177724
+haproxy/pcre2-10.41.tar.gz:
+  size: 2768681
+  object_id: f33637c2-64b5-4844-429b-34ca22bb46f6
+  sha: sha256:f1b010eb6b11eacd8e49f8803b863cbf63c44a63c8b7390fe3be03d8f6226dbf
 haproxy/socat-1.7.4.4.tar.gz:
   size: 662968
   object_id: 964b0dcf-b063-44d3-5955-e439b103c7a2

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 LUA_VERSION=5.4.4  # https://www.lua.org/ftp/lua-5.4.4.tar.gz
 
-PCRE_VERSION=10.40  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.gz
+PCRE_VERSION=10.41  # https://api.github.com/repos/PCRE2Project/pcre2/tarball/pcre2-10.41
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 10.40 to version 10.41, downloaded from https://api.github.com/repos/PCRE2Project/pcre2/tarball/pcre2-10.41.

After merge, consider releasing a new version of haproxy-boshrelease.
