### PR TITLE
Bump hatop version to 0.8.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,10 @@ haproxy/haproxy-2.6.7.tar.gz:
   size: 4028355
   object_id: 0889d657-c2c6-4c2d-4b3d-ba36bb16117d
   sha: sha256:cff9b8b18a52bfec277f9c1887fac93c18e1b9f3eff48892255a7c6e64528b7d
+haproxy/hatop-0.8.2:
+  size: 74157
+  object_id: 36e24366-438a-4d1e-6b43-019397107a2d
+  sha: sha256:6ba2136e98b9a436488be67a54a5295f55f38090157d09df0154dda493ac5815
 haproxy/hatop-0.8.2.tar.gz:
   size: 138030
   object_id: eca866ad-3c8f-4526-51d1-23179c1bbda8

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,6 @@ haproxy/hatop-0.8.2:
   size: 74157
   object_id: 36e24366-438a-4d1e-6b43-019397107a2d
   sha: sha256:6ba2136e98b9a436488be67a54a5295f55f38090157d09df0154dda493ac5815
-haproxy/hatop-0.8.2.tar.gz:
-  size: 138030
-  object_id: eca866ad-3c8f-4526-51d1-23179c1bbda8
-  sha: sha256:99f9cd9ec1bc2bb8b84da276e670002fe993f5b26e65c15f65e40fdcb42616cb
 haproxy/lua-5.4.4.tar.gz:
   size: 360876
   object_id: 5b2652c4-3c00-4d2d-742d-dda229e95bac

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -65,10 +65,8 @@ pushd haproxy-${HAPROXY_VERSION}
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy
 popd
 
-echo "Unpackaging and installing hatop..."
-mkdir hatop
-tar xzf haproxy/hatop-${HATOP_VERSION}.tar.gz -C hatop --strip-components=1 
-cp hatop/bin/hatop ${BOSH_INSTALL_TARGET}/bin/hatop
+echo "Installing hatop..."
+cp haproxy/hatop-${HATOP_VERSION} ${BOSH_INSTALL_TARGET}/bin/hatop
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/hatop
 cp hatop-wrapper ${BOSH_INSTALL_TARGET}/
 chmod 755 ${BOSH_INSTALL_TARGET}/hatop-wrapper

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -10,7 +10,7 @@ SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.
 
 HAPROXY_VERSION=2.6.7  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.7.tar.gz
 
-HATOP_VERSION=0.8.1  # https://api.github.com/repos/jhunt/hatop/tarball/v0.8.2
+HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -5,5 +5,5 @@ files:
 - haproxy/pcre2-*.tar.gz
 - haproxy/socat-*.tar.gz
 - haproxy/lua-*.tar.gz
-- haproxy/hatop-*.tar.gz
+- haproxy/hatop-*
 - hatop-wrapper


### PR DESCRIPTION

Automatic bump from version 0.8.1 to version 0.8.2, downloaded from https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop.

After merge, consider releasing a new version of haproxy-boshrelease.
