### PR TITLE
Add `allow_all` property to allow TCP traffic explicitly

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -527,6 +527,10 @@ properties:
     description: "Optionally block all incoming traffic to http(s). Use in conjunction with whitelist."
     default: false
 
+  ha_proxy.allow_all:
+    description: "Optionally allow all incoming traffic to http(s). Overrides cidr_whitelist and cidr_blacklist."
+    default: false
+
   ha_proxy.tcp_routing.port_range:
     description: "A range of ports for haproxy to listen on to enable CF TCP Routing. Used only if 'tcp_router' link is present."
     default: 1024-1123

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -370,6 +370,9 @@ frontend http-in
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
   <%- end -%>
+  <%- if p("ha_proxy.allow_all")  -%>
+    tcp-request content accept
+  <%- end -%>
     capture request header Host len 256
     default_backend <%= backends.last[:name] %>
   <%- if_p("ha_proxy.http_request_deny_conditions") do |conditions| -%>
@@ -601,6 +604,9 @@ frontend https-in
     acl is_http2 ssl_fc_alpn,lower,strcmp(proc.h2_alpn_tag) eq 0
     use_backend http-routers-http1 if ! is_http2
     use_backend http-routers-http2 if is_http2
+  <%- end -%>
+  <%- if p("ha_proxy.allow_all")  -%>
+    tcp-request content accept
   <%- end -%>
 # }}}
 <% end -%>

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -86,6 +86,16 @@ describe 'config/haproxy.config HTTP frontend' do
     end
   end
 
+  context 'when ha_proxy.allow_all is provided' do
+    let(:properties) do
+      { 'allow_all' => true }
+    end
+
+    it 'sets the correct content reject rules' do
+      expect(frontend_http).to include('tcp-request content accept')
+    end
+  end
+
   it 'correct request capturing configuration' do
     expect(frontend_http).to include('capture request header Host len 256')
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -528,6 +528,16 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
   end
 
+  context 'when ha_proxy.allow_all is provided' do
+    let(:properties) do
+      default_properties.merge({ 'allow_all' => true })
+    end
+
+    it 'sets the correct content reject rules' do
+      expect(frontend_https).to include('tcp-request content accept')
+    end
+  end
+
   context 'when ha_proxy.headers are provided' do
     let(:properties) do
       default_properties.merge({ 'headers' => ['X-Application-ID: my-custom-header', 'MyCustomHeader: 3'] })


### PR DESCRIPTION
This is useful when no allowlist is set, but all traffic should be allowed implicitly.