### PR TITLE
ci(autobumper): allow haproxy 2.7

### DIFF
--- a/ci/scripts/autobump-dependencies.py
+++ b/ci/scripts/autobump-dependencies.py
@@ -391,7 +391,7 @@ def main() -> None:
         HaproxyDependency(
             "haproxy",
             "HAPROXY_VERSION",
-            "2.6",
+            "2.7",
             "https://www.haproxy.org/download/{}/src",
         ),
         WebLinkDependency(


### PR DESCRIPTION
Preparation for HAProxy 2.7.x upgrade.