### PR TITLE
Move CI blobstore to GCS

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -363,7 +363,7 @@ jobs:
         params:
           rebase: true
           repository: pushme/git
-      - put: s3
+      - put: blobstore
         params:
           file:  "gh/artifacts/haproxy-*.tgz"
       - put: github
@@ -442,6 +442,11 @@ resource_types:
     source:
       repository: concourse/github-release-resource
 
+  - name: gcs
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource
+
 resources:
   - name: git
     type: git
@@ -476,13 +481,11 @@ resources:
   - name: version
     type: semver
     source :
-      driver:            s3
-      bucket:            cf-haproxy-boshrelease-pipeline
-      region_name:       us-east-1
-      key:               version
-      access_key_id:     ((aws.access_key))
-      secret_access_key: ((aws.secret_key))
-      initial_version:   "0.0.1"
+      driver:          gcs
+      bucket:          haproxy-boshrelease
+      key:             version
+      json_key:        ((gcp.service_key))
+      initial_version: "11.17.0"
 
   - name: notify
     type: slack-notification
@@ -496,14 +499,12 @@ resources:
       repository:   haproxy-boshrelease
       access_token: ((github.access_token))
 
-  - name: s3
-    type: s3
+  - name: blobstore
+    type: gcs
     source:
-      bucket:            cf-haproxy-boshrelease-pipeline
-      region_name:       us-east-1
-      regexp:            haproxy-([0-9\.]+).tgz
-      access_key_id:     ((aws.access_key))
-      secret_access_key: ((aws.secret_key))
+      bucket:   haproxy-boshrelease
+      json_key: ((gcp.service_key))
+      regexp:   haproxy-([0-9\.]+).tgz
 
   - name: daily
     type: time

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,24 +1,24 @@
 haproxy/haproxy-2.7.2.tar.gz:
   size: 4130348
-  object_id: 16482d54-23fb-44b5-7b69-8c2f2f5cf161
+  object_id: d068a4e4-439c-4c61-6c10-34da69bf5b13
   sha: sha256:63bc6ec0302d0ebbe1fa769c19606640de834ac8cb07447b80799cb563dc0f3f
 haproxy/hatop-0.8.2:
   size: 74157
-  object_id: 36e24366-438a-4d1e-6b43-019397107a2d
+  object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4
   sha: sha256:6ba2136e98b9a436488be67a54a5295f55f38090157d09df0154dda493ac5815
 haproxy/lua-5.4.4.tar.gz:
   size: 360876
-  object_id: 5b2652c4-3c00-4d2d-742d-dda229e95bac
+  object_id: a23b1602-be03-4bdf-485c-d72dcb81e3c2
   sha: sha256:164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61
 haproxy/pcre2-10.42.tar.gz:
   size: 2397194
-  object_id: 53997792-04ab-40b1-69fb-26c35c731cf2
+  object_id: 1411549b-cc2b-4140-68d1-f55bc6b17bef
   sha: sha256:c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f
 haproxy/socat-1.7.4.4.tar.gz:
   size: 662968
-  object_id: 964b0dcf-b063-44d3-5955-e439b103c7a2
+  object_id: 674c1075-b8d9-4b29-5af3-d0d0ed1cbb09
   sha: sha256:0f8f4b9d5c60b8c53d17b60d79ababc4a0f51b3bb6d2bd3ae8a6a4b9d68f195e
 keepalived/keepalived-2.2.7.tar.gz:
   size: 1180180
-  object_id: 1045d407-50f8-4580-57de-3ef787a88b28
+  object_id: c02487cf-d07c-4c46-576d-6ae6bb3ca51f
   sha: sha256:c61940d874154a560a54627ecf7ef47adebdf832164368d10bf242a4d9b7d49d

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,7 +1,6 @@
 ---
+name: haproxy
 blobstore:
-  provider: s3
+  provider: gcs
   options:
-    bucket_name: cf-haproxy-boshrelease # leaving as old release name for blob compatibility
-
-final_name: haproxy
+    bucket_name: haproxy-boshrelease


### PR DESCRIPTION
AWS S3 keys were rotated. The WG also moved to GCS for storage.

Added a new bucket `haproxy-boshrelease` on the account "App-Runtime-Platform-WG".

This PR uses this new bucket for version tracking and release uploads.