### PR TITLE
doc: fix description of client_cert_ignore_err

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -443,13 +443,13 @@ properties:
 
   ha_proxy.client_cert_ignore_err:
     description: |
-      Error code(s) to ignore from verifying a client cert during a mutual ssl handshake, in a pipe-separated list.
+      Error code(s) to ignore from verifying a client cert during a mutual ssl handshake, in a comma-separated list.
       For example, 2 is if it cannot get the issuer certificate, 10 if the certificate has expired and 18 if the certificate is self-signed.
       The keyword 'all' will ignore all possible errors.
       Note that the errors will be ignored on both the certificate and the CA verification.
       See the openssl verify documentation [https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get_error.html] for a full list of all error codes and their meanings.
       See https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in#L206 for a mapping of error codes to symbols.
-    example: 2|10|18
+    example: 2,10,18
 
   ha_proxy.client_revocation_list:
     description: "provide a list of revocation certs"


### PR DESCRIPTION
This commit changes the documentation that stated the separator for multiple error codes would be a pipe but it actually is a comma.

See: https://docs.haproxy.org/2.7/configuration.html#5.1-ca-ignore-err