### PR TITLE
Shipit: Fix incorrect YAML padding

### DIFF
--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -26,17 +26,17 @@ header() {
 : "${VERSION_FROM:?required}"
 : "${GCP_SERVICE_KEY:?required}"
 
-if [[ ! -f ${VERSION_FROM} ]]; then
+if [[ ! -f "${VERSION_FROM}" ]]; then
   echo >&2 "Version file (${VERSION_FROM}) not found.  Did you misconfigure Concourse?"
   exit 2
 fi
-VERSION=$(cat ${VERSION_FROM})
-if [[ -z ${VERSION} ]]; then
+VERSION=$(cat "${VERSION_FROM}")
+if [[ -z "${VERSION}" ]]; then
   echo >&2 "Version file (${VERSION_FROM}) was empty.  Did you misconfigure Concourse?"
   exit 2
 fi
 
-if [[ ! -f ${REPO_ROOT}/ci/release_notes.md ]]; then
+if [[ ! -f "${REPO_ROOT}/ci/release_notes.md" ]]; then
   echo >&2 "ci/release_notes.md not found.  Did you forget to write them?"
   exit 1
 fi
@@ -45,13 +45,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ###############################################################
 
-cd ${REPO_ROOT}
+cd "${REPO_ROOT}"
 RELEASE_NAME=$(bosh int config/final.yml --path /name)
 
 # YAML needs to be indented. The GCP service key is a multiline YAML and needs to be indented uniformly.
-INDENT=6
-PAD=$(printf ' %.0s' {1..$INDENT})
-PADDED_GCP_SERVICE_KEY=$(sed -E 's/^(.*)$/'"$PAD"'\1/g' <<<"$GCP_SERVICE_KEY")
+# Bash does not allow variables in a sequence literal. $PAD is a 6 spaces indent.
+PAD=$(printf ' %.0s' {1..6})
+PADDED_GCP_SERVICE_KEY=$(sed -E 's/^(.*)$/'"${PAD}"'\1/g' <<<"${GCP_SERVICE_KEY}")
 
 cat > config/private.yml <<YAML
 ---
@@ -67,27 +67,32 @@ git submodule update --init --recursive --force
 
 header "Create final release..."
 bosh -n create-release --final --version "${VERSION}"
-bosh -n create-release releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.yml \
-              --tarball releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.tgz
+bosh -n create-release "releases/${RELEASE_NAME}/${RELEASE_NAME}-${VERSION}.yml" \
+              --tarball "releases/${RELEASE_NAME}/${RELEASE_NAME}-${VERSION}.tgz"
 cd -
 
-RELEASE_TGZ=$REPO_ROOT/releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION.tgz
-export SHA1=$(sha1sum "$RELEASE_TGZ" | head -n1 | awk '{print $1}')
-echo "SHA1=$SHA1"
-export SHA256=$(sha256sum "$RELEASE_TGZ" | head -n1 | awk '{print $1}')
-echo "SHA256=$SHA256"
+# SC2155 discourages variable assignment and export in the same line.
+RELEASE_TGZ=${REPO_ROOT}/releases/${RELEASE_NAME/}${RELEASE_NAME}-${VERSION}.tgz
+# shellcheck disable=SC2155
+export SHA1=$(sha1sum "${RELEASE_TGZ}" | head -n1 | awk '{print $1}')
+echo "SHA1=${SHA1}"
+# shellcheck disable=SC2155
+export SHA256=$(sha256sum "${RELEASE_TGZ}" | head -n1 | awk '{print $1}')
+echo "SHA256=${SHA256}"
 
-PATCHED_RELEASE_TGZ=$REPO_ROOT/releases/$RELEASE_NAME/${RELEASE_NAME}_patched-$VERSION.tgz
-export PATCHED_SHA1=$(sha1sum "$PATCHED_RELEASE_TGZ" | head -n1 | awk '{print $1}')
-echo "PATCHED_SHA1=$PATCHED_SHA1"
-export PATCHED_SHA256=$(sha256sum "$PATCHED_RELEASE_TGZ" | head -n1 | awk '{print $1}')
-echo "PATCHED_SHA256=$PATCHED_SHA256"
+PATCHED_RELEASE_TGZ=${REPO_ROOT}/releases/${RELEASE_NAME}/${RELEASE_NAME}_patched-${VERSION}.tgz
+# shellcheck disable=SC2155
+export PATCHED_SHA1=$(sha1sum "${PATCHED_RELEASE_TGZ}" | head -n1 | awk '{print $1}')
+echo "PATCHED_SHA1=${PATCHED_SHA1}"
+# shellcheck disable=SC2155
+export PATCHED_SHA256=$(sha256sum "${PATCHED_RELEASE_TGZ}" | head -n1 | awk '{print $1}')
+echo "PATCHED_SHA256=${PATCHED_SHA256}"
 
 mkdir -p "${RELEASE_ROOT}/artifacts"
-echo "v${VERSION}"                         > ${RELEASE_ROOT}/tag
-echo "v${VERSION}"                         > ${RELEASE_ROOT}/name
-mv ${REPO_ROOT}/releases/*/*-${VERSION}.tgz  ${RELEASE_ROOT}/artifacts
-mv ${REPO_ROOT}/ci/release_notes.md          ${RELEASE_ROOT}/notes.md
+echo "v${VERSION}"                         > "${RELEASE_ROOT}/tag"
+echo "v${VERSION}"                         > "${RELEASE_ROOT}/name"
+mv "${REPO_ROOT}/releases/*/*-${VERSION}.tgz"  "${RELEASE_ROOT}/artifacts"
+mv "${REPO_ROOT}/ci/release_notes.md"          "${RELEASE_ROOT}/notes.md"
 
 version() {
   # extract the version variable $1 from the packaging script $2 (default 'haproxy')
@@ -103,7 +108,7 @@ SOCAT_VERSION=$(version SOCAT_VERSION)
 PCRE_VERSION=$(version PCRE_VERSION)
 KEEPALIVED_VERSION=$(version KEEPALIVED_VERSION keepalived)
 
-cat >> ${RELEASE_ROOT}/notes.md <<EOF
+cat >> "${RELEASE_ROOT}/notes.md" <<EOF
 ### Versions
 
 The following versions of upstream components are included in this haproxy-boshrelease:
@@ -119,27 +124,27 @@ The following versions of upstream components are included in this haproxy-boshr
 ### Deployment
 \`\`\`yaml
 releases:
-- name: "$RELEASE_NAME"
-  version: "$VERSION"
+- name: "${RELEASE_NAME}"
+  version: "${VERSION}"
   url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz"
-  sha1: "$SHA1"
+  sha1: "${SHA1}"
 
 # for deployments with sha256, use the following line instead:
-# sha1: "sha256:$SHA256"
+# sha1: "sha256:${SHA256}"
 
 ### Deployment (patched)
 \`\`\`yaml
 releases:
-- name: "$RELEASE_NAME"
-  version: "$VERSION"
+- name: "${RELEASE_NAME}"
+  version: "${VERSION}"
   url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}_patched-${VERSION}.tgz"
-  sha1: "$PATCHED_SHA1"
+  sha1: "${PATCHED_SHA1}"
 
 # for deployments with sha256, use the following line instead:
-# sha1: "sha256:$PATCHED_SHA256"
+# sha1: "sha256:${PATCHED_SHA256}"
 \`\`\`
 EOF
-cat > ${RELEASE_ROOT}/notification <<EOF
+cat > "${RELEASE_ROOT}/notification" <<EOF
 <!here> New ${RELEASE_NAME} v${VERSION} released!
 EOF
 
@@ -153,8 +158,8 @@ if [[ -z $(git config --global user.name) ]]; then
 fi
 
 pushd "${REPO_ROOT}"
-  for MANIFEST_PATH in $(ls manifests/*.yml); do
-    $DIR/update-manifest ${GITHUB_OWNER} ${RELEASE_NAME} ${VERSION} ${SHA1} ${MANIFEST_PATH}
+  for MANIFEST_PATH in manifests/*.yml; do
+    "${DIR}/update-manifest" "${GITHUB_OWNER}" "${RELEASE_NAME}" "${VERSION}" "${SHA1}" "${MANIFEST_PATH}"
   done
   git merge --no-edit "${BRANCH}"
   git add -A
@@ -175,11 +180,11 @@ pushd "${REPO_ROOT}"
   git reset --hard
 popd
 
-mv ${RELEASE_NAME}_patched-$VERSION.tgz ${RELEASE_ROOT}/artifacts
+mv "${RELEASE_NAME}_patched-${VERSION}.tgz" "${RELEASE_ROOT}/artifacts"
 
 # so that future steps in the pipeline can push our changes
-cp -a ${REPO_ROOT} ${REPO_OUT}
+cp -a "${REPO_ROOT}" "${REPO_OUT}"
 
-cat > ${NOTIFICATION_OUT:-notifications}/message <<EOS
+cat > "${NOTIFICATION_OUT:-notifications}/message" <<EOS
 New ${RELEASE_NAME} v${VERSION} released. <https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/tag/v${VERSION}|Release notes>.
 EOS


### PR DESCRIPTION
Yaml padding broke in #356 after addressing review comments and running into a bash limitation (no variable expansion in sequence literals)