### PR TITLE
Remove acknowledgement from release notes template

### DIFF
--- a/ci/release_notes_template.md
+++ b/ci/release_notes_template.md
@@ -9,7 +9,3 @@
 # Upgrades
 
 - `component` has been upgraded from v1.0.0 to v1.2.3
-
-# Acknowledgements
-
-Thanks @person for the PR / fixes!

--- a/ci/release_notes_template.md
+++ b/ci/release_notes_template.md
@@ -1,10 +1,10 @@
 # Fixes
-- fix a
-- fix b
+- fix a (@personA)
+- fix b (@personB)
 
 # New Features
-- feature a
-- feature b
+- feature a (@personA)
+- feature b (@personB)
 
 # Upgrades
 


### PR DESCRIPTION
Contributors are shown by github, no extra section needed