### PR TITLE
Bump haproxy version to 2.7.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.7.3.tar.gz:
-  size: 4141275
-  object_id: 45281026-5364-4b94-7f16-7c01fa6c4ee7
-  sha: sha256:b17e51b96531843b4a99d2c3b6218281bc988bf624c9ff90e19f0cbcba25d067
+haproxy/haproxy-2.7.4.tar.gz:
+  size: 4154182
+  object_id: 909eae96-fd12-45eb-61c1-bc5eb869eadb
+  sha: sha256:84cb806030569e866812eed38ebd1a8ea6fe1d9800001e59924ec3dd39553b9f
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.7.3  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.3.tar.gz
+HAPROXY_VERSION=2.7.4  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.4.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.7.3 to version 2.7.4, downloaded from https://www.haproxy.org/download/2.7/src/haproxy-2.7.4.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
