### PR TITLE
Bump haproxy version to 2.7.6

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.7.5.tar.gz:
-  size: 4160630
-  object_id: 65547552-7580-47e9-6068-102785d198c0
-  sha: sha256:e2c6e43270c35a4009a70052d26c1ddb90b63a650f81305a748f229737a74502
+haproxy/haproxy-2.7.6.tar.gz:
+  size: 4162978
+  object_id: d9481c14-335f-457b-7bde-8e4ba9657047
+  sha: sha256:133f357ddb3fcfc5ad8149ef3d74cbb5db6bb4a5ab67289ce0b0ab686cdeb74f
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.7.5  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.5.tar.gz
+HAPROXY_VERSION=2.7.6  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.6.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.7.5 to version 2.7.6, downloaded from https://www.haproxy.org/download/2.7/src/haproxy-2.7.6.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
