### PR TITLE
Create second pipeline to support release based on previous haproxy version

### DIFF
--- a/ci/pipeline-haproxy-maintenance.yml
+++ b/ci/pipeline-haproxy-maintenance.yml
@@ -378,7 +378,7 @@ jobs:
           repository: pushme/git-previous-release
       - put: blobstore
         params:
-          file:  "gh/artifacts/haproxy-[0-9+-.A-z]+.tgz"
+          file:  "gh/artifacts/haproxy-*.tgz"
       - put: github
         params:
           name:   gh/name
@@ -513,7 +513,7 @@ resources:
     source:
       bucket:   haproxy-boshrelease
       json_key: ((gcp.service_key))
-      regexp:   haproxy-([0-9\.]+).tgz
+      regexp:   haproxy-([0-9\.+-]+).tgz
 
   - name: daily
     type: time

--- a/ci/pipeline-haproxy-maintenance.yml
+++ b/ci/pipeline-haproxy-maintenance.yml
@@ -378,7 +378,7 @@ jobs:
           repository: pushme/git-previous-release
       - put: blobstore
         params:
-          file:  "gh/artifacts/haproxy-*.tgz"
+          file:  "gh/artifacts/haproxy-[0-9+-.A-z]+.tgz"
       - put: github
         params:
           name:   gh/name

--- a/ci/pipeline-haproxy-maintenance.yml
+++ b/ci/pipeline-haproxy-maintenance.yml
@@ -384,7 +384,7 @@ jobs:
           name:   gh/name
           tag:    gh/tag
           body:   gh/notes.md
-          globs: [gh/artifacts/*]
+          globs: [gh/artifacts/*, gh/artifacts-patched/*]
       - put: notify
         params:
           channel:  "#haproxy-boshrelease"

--- a/ci/pipeline-haproxy-maintenance.yml
+++ b/ci/pipeline-haproxy-maintenance.yml
@@ -1,0 +1,524 @@
+---
+
+groups:
+  - name: haproxy-boshrelease-maintenance
+    jobs:
+      - unit-tests
+      - unit-tests-pr
+      - acceptance-tests
+      - acceptance-tests-pr
+      - pre
+      - rc
+      - shipit
+      - patch
+      - minor
+      - major
+      - autobump-dependencies
+
+jobs:
+  - name: unit-tests
+    public: true
+    serial: true
+    plan:
+    - do:
+      - get: git-previous-release
+        trigger: true
+      - task: lint
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          inputs:
+            - { name: git-previous-release }
+          caches:
+          - path: git-previous-release/vendor/cache
+          - path: git-previous-release/.bundle
+          run:
+            path: ./git-previous-release/ci/scripts/lint
+            args: []
+          params:
+            REPO_ROOT: git-previous-release
+      - task: unit-tests
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          inputs:
+            - { name: git-previous-release }
+          caches:
+          - path: git-previous-release/vendor/cache
+          - path: git-previous-release/.bundle
+          run:
+            path: ./git-previous-release/ci/scripts/unit-tests
+            args: []
+          params:
+            REPO_ROOT: git-previous-release
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text:    "((slack.fail_url)) haproxy-boshrelease : unit-tests job failed"
+
+  - name: unit-tests-pr
+    public: true
+    serial: true
+    plan:
+    - do:
+      - { get: git-pull-requests-previous-release, trigger: true, version: every }
+      - put: git-pull-requests-previous-release
+        params:
+          path: git-pull-requests-previous-release
+          status: pending
+          context: unit-tests
+      - task: lint
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          inputs:
+            - { name: git-pull-requests-previous-release }
+          caches:
+          - path: git-pull-requests-previous-release/vendor/cache
+          - path: git-pull-requests-previous-release/.bundle
+          run:
+            path: ./git-pull-requests-previous-release/ci/scripts/lint
+            args: []
+          params:
+            REPO_ROOT: git-pull-requests-previous-release
+      - task: unit-tests
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          inputs:
+            - { name: git-pull-requests-previous-release }
+          caches:
+          - path: git-pull-requests-previous-release/vendor/cache
+          - path: git-pull-requests-previous-release/.bundle
+          run:
+            path: ./git-pull-requests-previous-release/ci/scripts/unit-tests
+            args: []
+          params:
+            REPO_ROOT: git-pull-requests-previous-release
+    on_success:
+      put: git-pull-requests-previous-release
+      params:
+        path: git-pull-requests-previous-release
+        status: success
+        context: unit-tests
+    on_failure:
+      put: git-pull-requests-previous-release
+      params:
+        path: git-pull-requests-previous-release
+        status: failure
+        context: unit-tests
+
+
+  - name: acceptance-tests
+    public: true
+    serial: true
+    plan:
+    - do:
+      - in_parallel:
+        - { get: git-previous-release, trigger: true, passed: [unit-tests] }
+        - { get: stemcell }
+        - { get: stemcell-bionic }
+        - { get: bpm }
+      - task: acceptance-tests
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          inputs:
+            - { name: git-previous-release }
+            - { name: stemcell }
+            - { name: stemcell-bionic }
+            - { name: bpm }
+          run:
+            path: ./git-previous-release/ci/scripts/acceptance-tests
+            args: []
+          params:
+            REPO_ROOT:            git-previous-release
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text:    "((slack.fail_url)) haproxy-boshrelease : acceptance tests failed"
+
+  - name: acceptance-tests-pr
+    public: true
+    serial: true
+    plan:
+    - do:
+      - { get: git-pull-requests-previous-release, trigger: true, version: every, passed: [unit-tests-pr] }
+      - { get: stemcell }
+      - { get: stemcell-bionic }
+      - { get: bpm }
+      - put: git-pull-requests-previous-release
+        params:
+          path: git-pull-requests-previous-release
+          status: pending
+          context: acceptance-tests
+      - task: acceptance-tests
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag: latest
+              username: ((docker.username))
+              password: ((docker.password))
+          inputs:
+            - { name: git-pull-requests-previous-release }
+            - { name: stemcell }
+            - { name: stemcell-bionic }
+            - { name: bpm }
+          run:
+            path: ./git-pull-requests-previous-release/ci/scripts/acceptance-tests
+            args: []
+          params:
+            REPO_ROOT:            git-pull-requests-previous-release
+    on_success:
+      put: git-pull-requests-previous-release
+      params:
+        path: git-pull-requests-previous-release
+        status: success
+        context: acceptance-tests
+    on_failure:
+      put: git-pull-requests-previous-release
+      params:
+        path: git-pull-requests-previous-release
+        status: failure
+        context: acceptance-tests
+
+  - name: pre
+    public: true
+    serial: true
+    plan:
+    - do:
+      - get: git-previous-release
+        passed:
+        - acceptance-tests
+        trigger: true
+      - get: version
+        trigger: true
+      - task: release-notes
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          run:
+            path: sh
+            args:
+            - -ce
+            - |
+              cd git-previous-release
+              if [ -f ci/release_notes.md ]; then
+                echo "######   RELEASE NOTES   ###############"
+                echo
+                cat ci/release_notes.md
+                echo
+                echo "########################################"
+                echo
+              else
+                echo "NO RELEASE NOTES HAVE BEEN WRITTEN"
+                echo "You *might* want to do that before"
+                echo "hitting (+) on that shipit job..."
+                echo
+              fi
+          inputs:
+          - name: git-previous-release
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text: release candidate job 'pre' failed (which is unusual).
+          ok: false
+
+  - name: rc
+    public: true
+    plan:
+    - do:
+      - in_parallel:
+          - { get: git-previous-release,     trigger: true,  passed: [pre] }
+          - { get: version, trigger: false, params: {pre: rc} }
+      - put: version
+        params: {file: version/number}
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text:    "((slack.fail_url)) haproxy-boshrelease : rc job failed"
+
+  - name: patch
+    public: true
+    plan:
+      - do:
+          - { get: version, trigger: false, params: {bump: patch} }
+          - { put: version,                 params: {file: version/number} }
+        on_failure:
+          put: notify
+          params:
+            channel:  "#haproxy-boshrelease"
+            username: ci-bot
+            icon_url: "((slack.icon))"
+            text:    "((slack.fail_url)) haproxy-boshrelease : patch job failed"
+
+  - name: minor
+    public: true
+    plan:
+    - do:
+      - { get: version, trigger: false, params: {bump: minor} }
+      - { put: version,                 params: {file: version/number} }
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text:    "((slack.fail_url)) haproxy-boshrelease : minor job failed"
+
+  - name: major
+    public: true
+    plan:
+    - do:
+      - { get: version, trigger: false, params: {bump: major} }
+      - { put: version,                 params: {file: version/number} }
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text:    "((slack.fail_url)) haproxy-boshrelease : major job failed"
+
+  - name: shipit
+    public: true
+    serial: true
+    plan:
+    - do:
+      - in_parallel:
+          - { get: version, passed: [rc], params: {bump: final} }
+          - { get: git-previous-release,     passed: [rc] }
+      - task: release
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+              tag:        latest
+              username:   ((docker.username))
+              password:   ((docker.password))
+          inputs:
+            - name: version
+            - name: git-previous-release
+          outputs:
+            - name: gh
+            - name: pushme
+            - name: notifications
+          run:
+            path: ./git-previous-release/ci/scripts/shipit
+            args: []
+          params:
+            REPO_ROOT:    git-previous-release
+            VERSION_FROM: version/number
+            RELEASE_ROOT: gh
+            REPO_OUT:     pushme
+            NOTIFICATION_OUT: notifications
+            BRANCH:        maintenance
+            GITHUB_OWNER:  cloudfoundry
+
+            GCP_SERVICE_KEY: ((gcp.service_key))
+
+      - put: git-previous-release
+        params:
+          rebase: true
+          repository: pushme/git-previous-release
+      - put: blobstore
+        params:
+          file:  "gh/artifacts/haproxy-*.tgz"
+      - put: github
+        params:
+          name:   gh/name
+          tag:    gh/tag
+          body:   gh/notes.md
+          globs: [gh/artifacts/*]
+      - put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text_file: notifications/message
+      on_failure:
+        put: notify
+        params:
+          channel:  "#haproxy-boshrelease"
+          username: ci-bot
+          icon_url: "((slack.icon))"
+          text:    "((slack.fail_url)) haproxy-boshrelease : shipit job failed"
+  - name: autobump-dependencies
+    public: true
+    serial: true
+    plan:
+      - do:
+          - get: daily
+            trigger: true
+          - get: git-previous-release
+          - task: autobump-dependencies
+            config:
+              inputs:
+                - name: git-previous-release
+              platform: linux
+              image_resource:
+                type: docker-image
+                source:
+                  repository: iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight
+                  tag: latest
+                  username: ((docker.username))
+                  password: ((docker.password))
+              run:
+                dir: git-previous-release
+                path: /usr/bin/python3
+                args: ["ci/scripts/autobump-dependencies.py"]
+              params:
+                REPO_ROOT: git-previous-release
+                PR_BASE: maintenance
+                PR_ORG: cloudfoundry
+                PR_LABEL: run-ci
+
+                GCP_SERVICE_KEY: ((gcp.service_key))
+                GITHUB_COM_TOKEN: ((github.access_token))
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+
+  # FIXME: Need to use latest version of this resource due to
+  # https://github.com/concourse/github-release-resource/issues/108
+  # https://github.com/concourse/github-release-resource/pull/107
+  # Until Concourse is updated to 7.5.0+
+  - name: github-release-alt
+    type: registry-image
+    source:
+      repository: concourse/github-release-resource
+
+  - name: gcs
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource
+
+resources:
+  - name: git-previous-release
+    type: git
+    source:
+      uri:         git@github.com:cloudfoundry/haproxy-boshrelease.git
+      branch:      maintenance
+      private_key: ((github.private_key))
+
+  - name: git-pull-requests-previous-release
+    type: pull-request
+    source:
+      access_token: ((github.access_token))
+      repository:   cloudfoundry/haproxy-boshrelease
+      base_branch:  maintenance
+      labels:       [run-ci]
+
+  - name: stemcell-bionic
+    type: bosh-io-stemcell
+    source:
+      name: bosh-warden-boshlite-ubuntu-bionic-go_agent
+
+  - name: stemcell
+    type: bosh-io-stemcell
+    source:
+      name: bosh-warden-boshlite-ubuntu-jammy-go_agent
+
+  - name: bpm
+    type: bosh-io-release
+    source:
+      repository: cloudfoundry/bpm-release
+
+  - name: version
+    type: semver
+    source :
+      driver:          gcs
+      bucket:          haproxy-boshrelease-maintenance
+      key:             version-11.16
+      json_key:        ((gcp.service_key))
+      initial_version: "11.16.3"
+
+  - name: notify
+    type: slack-notification
+    source:
+      url: ((slack.webhook))
+
+  - name: github
+    type: github-release-alt
+    source:
+      user:         cloudfoundry
+      repository:   haproxy-boshrelease
+      access_token: ((github.access_token))
+
+  - name: blobstore
+    type: gcs
+    source:
+      bucket:   haproxy-boshrelease
+      json_key: ((gcp.service_key))
+      regexp:   haproxy-([0-9\.]+).tgz
+
+  - name: daily
+    type: time
+    source:
+      start: 7:00 AM
+      stop: 8:00 AM
+      location: Europe/Berlin
+      interval: 24h

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -370,7 +370,7 @@ jobs:
           name:   gh/name
           tag:    gh/tag
           body:   gh/notes.md
-          globs: [gh/artifacts/*]
+          globs: [gh/artifacts/*, gh/artifacts-patched/*]
       - put: version
         params:
           bump: patch
@@ -502,7 +502,7 @@ resources:
     source:
       bucket:   haproxy-boshrelease
       json_key: ((gcp.service_key))
-      regexp:   haproxy-([0-9\.]+).tgz
+      regexp:   haproxy-([0-9\.+-]+).tgz
 
   - name: daily
     type: time

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -167,9 +167,10 @@ pushd "${REPO_ROOT}"
   git reset --hard
 popd
 
-mv "${RELEASE_NAME}-${VERSION}-patched.tgz" "${RELEASE_ROOT}/artifacts"
+mkdir -p "${RELEASE_ROOT}/artifacts-patched"
+mv "${RELEASE_NAME}-${VERSION}-patched.tgz" "${RELEASE_ROOT}/artifacts-patched"
 
-PATCHED_RELEASE_TGZ=${RELEASE_ROOT}/artifacts/${RELEASE_NAME}-${VERSION}-patched.tgz
+PATCHED_RELEASE_TGZ=${RELEASE_ROOT}/artifacts-patched/${RELEASE_NAME}-${VERSION}-patched.tgz
 # shellcheck disable=SC2155
 export PATCHED_SHA1=$(sha1sum "${PATCHED_RELEASE_TGZ}" | head -n1 | awk '{print $1}')
 echo "PATCHED_SHA1=${PATCHED_SHA1}"

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -30,8 +30,8 @@ if [[ ! -f "${VERSION_FROM}" ]]; then
   echo >&2 "Version file (${VERSION_FROM}) not found.  Did you misconfigure Concourse?"
   exit 2
 fi
-VERSION=$(cat "${VERSION_FROM}")
-if [[ -z "${VERSION}" ]]; then
+VERSION_TO_CREATE=$(cat "${VERSION_FROM}")
+if [[ -z "${VERSION_TO_CREATE}" ]]; then
   echo >&2 "Version file (${VERSION_FROM}) was empty.  Did you misconfigure Concourse?"
   exit 2
 fi
@@ -64,7 +64,25 @@ YAML
 
 header "Pulling in any git submodules..."
 git submodule update --init --recursive --force
+cd -
 
+version() {
+  # extract the version variable $1 from the packaging script $2 (default 'haproxy')
+  pattern='s/VERSION=(.*)(\s?#.*)/\1/p'
+  package=${2:-haproxy}
+  # extract version and remove all spaces
+  sed -n -E "${pattern//VERSION/${1:?}}" "${REPO_ROOT}/packages/${package}/packaging" | sed 's/ *//g'
+}
+
+HAPROXY_VERSION=$(version HAPROXY_VERSION)
+LUA_VERSION=$(version LUA_VERSION)
+SOCAT_VERSION=$(version SOCAT_VERSION)
+PCRE_VERSION=$(version PCRE_VERSION)
+KEEPALIVED_VERSION=$(version KEEPALIVED_VERSION keepalived)
+
+VERSION="${VERSION_TO_CREATE}+${HAPROXY_VERSION}"
+
+cd "${REPO_ROOT}"
 header "Create final release..."
 bosh -n create-release --final --version "${VERSION}"
 bosh -n create-release "releases/${RELEASE_NAME}/${RELEASE_NAME}-${VERSION}.yml" \
@@ -80,25 +98,13 @@ echo "SHA1=${SHA1}"
 export SHA256=$(sha256sum "${RELEASE_TGZ}" | head -n1 | awk '{print $1}')
 echo "SHA256=${SHA256}"
 
+
+
 mkdir -p "${RELEASE_ROOT}/artifacts"
 echo "v${VERSION}"                            > "${RELEASE_ROOT}/tag"
 echo "v${VERSION}"                            > "${RELEASE_ROOT}/name"
 mv "${REPO_ROOT}"/releases/*/*-"${VERSION}".tgz "${RELEASE_ROOT}/artifacts"
 mv "${REPO_ROOT}/ci/release_notes.md"           "${RELEASE_ROOT}/notes.md"
-
-version() {
-  # extract the version variable $1 from the packaging script $2 (default 'haproxy')
-  pattern='s/VERSION=(.*)(\s?#.*)/\1/p'
-  package=${2:-haproxy}
-  # extract version and remove all spaces
-  sed -n -E "${pattern//VERSION/${1:?}}" "${REPO_ROOT}/packages/${package}/packaging" | sed 's/ *//g'
-}
-
-HAPROXY_VERSION=$(version HAPROXY_VERSION)
-LUA_VERSION=$(version LUA_VERSION)
-SOCAT_VERSION=$(version SOCAT_VERSION)
-PCRE_VERSION=$(version PCRE_VERSION)
-KEEPALIVED_VERSION=$(version KEEPALIVED_VERSION keepalived)
 
 cat >> "${RELEASE_ROOT}/notes.md" <<EOF
 ### Versions
@@ -154,16 +160,16 @@ pushd "${REPO_ROOT}"
   bosh upload-blobs
 
   bosh -n create-release --force --version "${VERSION}-patched" \
-    --tarball "../${RELEASE_NAME}_patched-${VERSION}.tgz"
+    --tarball "../${RELEASE_NAME}-${VERSION}-patched.tgz"
 
   # Undo changes to repo from creating dev release
   git clean -df
   git reset --hard
 popd
 
-mv "${RELEASE_NAME}_patched-${VERSION}.tgz" "${RELEASE_ROOT}/artifacts"
+mv "${RELEASE_NAME}-${VERSION}-patched.tgz" "${RELEASE_ROOT}/artifacts"
 
-PATCHED_RELEASE_TGZ=${RELEASE_ROOT}/artifacts/${RELEASE_NAME}_patched-${VERSION}.tgz
+PATCHED_RELEASE_TGZ=${RELEASE_ROOT}/artifacts/${RELEASE_NAME}-${VERSION}-patched.tgz
 # shellcheck disable=SC2155
 export PATCHED_SHA1=$(sha1sum "${PATCHED_RELEASE_TGZ}" | head -n1 | awk '{print $1}')
 echo "PATCHED_SHA1=${PATCHED_SHA1}"
@@ -177,8 +183,8 @@ cat >> "${RELEASE_ROOT}/notes.md" <<EOF
 \`\`\`yaml
 releases:
 - name: "${RELEASE_NAME}"
-  version: "${VERSION}"
-  url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}_patched-${VERSION}.tgz"
+  version: "${VERSION}-patched"
+  url: "https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}-patched.tgz"
   sha1: "${PATCHED_SHA1}"
 
 # for deployments with sha256, use the following line instead:

--- a/ci/upload-to-concourse.sh
+++ b/ci/upload-to-concourse.sh
@@ -33,4 +33,8 @@ fly -t "$CONCOURSE_TARGET" validate-pipeline -c pipeline.yml
 fly -t "$CONCOURSE_TARGET" set-pipeline -p haproxy-boshrelease -c pipeline.yml --load-vars-from vars.yml
 fly -t "$CONCOURSE_TARGET" expose-pipeline -p haproxy-boshrelease
 
+fly -t "$CONCOURSE_TARGET" validate-pipeline -c pipeline-haproxy-maintenance.yml
+fly -t "$CONCOURSE_TARGET" set-pipeline -p haproxy-boshrelease-maintenance -c pipeline-haproxy-maintenance.yml --load-vars-from vars.yml
+fly -t "$CONCOURSE_TARGET" expose-pipeline -p haproxy-boshrelease-maintenance
+
 echo "Done."


### PR DESCRIPTION
- Add new pipeline in order to create a release based on previous stable haproxy version 
- Make sure that the autobump-dependencies is using the maintenance branch
- Adjust initial_version to versioning
- Use new shipit logic which fits to versioning guide