### PR TITLE
fix(ci): bump go in testflight image and fix spruce dependency

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,14 +1,12 @@
 FROM bosh/main-bosh-docker
 
-ARG GINKGO_VERSION=v2.2.0
+ARG GINKGO_VERSION=v2.9.2
+ARG SPRUCE_VERSION=v1.30.2
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install all necessary tools for haproxy testflight and dependency autobump
-RUN apt-get update && apt-get install -y wget jq git vim nano python3-pip\
-  && wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | apt-key add - \
-  && echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list \
-  && apt-get update && apt-get install -y wget spruce && apt-get clean
+RUN apt-get update && apt-get install -y wget jq git vim nano python3-pip
 
 # Set bosh env at login
 RUN echo "source /tmp/local-bosh/director/env" >> /root/.bashrc
@@ -19,6 +17,11 @@ RUN echo "export PATH=\$PATH:\$GOPATH/bin" >> /root/.bashrc
 COPY scripts/requirements.txt /requirements.txt
 RUN /usr/bin/python3 -m pip install -r /requirements.txt
 
-ENV GOPATH=/go
+ADD --chmod=755 https://github.com/geofffranks/spruce/releases/download/${SPRUCE_VERSION}/spruce-linux-amd64 /usr/local/bin/spruce
+RUN rm -rf /usr/local/go/ && mkdir -p /usr/local/go/
+COPY --from=golang:1.20 /usr/local/go/ /usr/local/go/
+
 RUN mkdir /go
+ENV GOPATH=/go PATH=${PATH}:/go/bin
+
 RUN go install "github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM bosh/main-bosh-docker
+FROM bosh/docker-cpi:main
 
 ARG GINKGO_VERSION=v2.9.2
 ARG SPRUCE_VERSION=v1.30.2


### PR DESCRIPTION
The `bosh/main-bosh-docker` image is deprecated. It is instead moving to `bosh/docker-cpi:main`.

Spruce was pulled in from `apt.starkandwayne.com`, which is not reachable anymore. Instead pulling the binary from GitHub releases directly.

Also replaces Go from the `golang:1.20` image (currently 1.20.3)