### PR TITLE
Bump haproxy version to 2.7.7

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.7.6.tar.gz:
-  size: 4162978
-  object_id: d9481c14-335f-457b-7bde-8e4ba9657047
-  sha: sha256:133f357ddb3fcfc5ad8149ef3d74cbb5db6bb4a5ab67289ce0b0ab686cdeb74f
+haproxy/haproxy-2.7.7.tar.gz:
+  size: 4176633
+  object_id: 0f015267-348f-4a74-564e-6d83652e528e
+  sha: sha256:d0f89cb3244fc7bd93b6a6e9aabfc564f21386867288b5dd93160913e6cc4b89
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.7.6  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.6.tar.gz
+HAPROXY_VERSION=2.7.7  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.7.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.7.6 to version 2.7.7, downloaded from https://www.haproxy.org/download/2.7/src/haproxy-2.7.7.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
