### PR TITLE
Bump haproxy version to 2.7.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.7.7.tar.gz:
-  size: 4176633
-  object_id: 0f015267-348f-4a74-564e-6d83652e528e
-  sha: sha256:d0f89cb3244fc7bd93b6a6e9aabfc564f21386867288b5dd93160913e6cc4b89
+haproxy/haproxy-2.7.8.tar.gz:
+  size: 4176647
+  object_id: 41f3d1ad-081d-42da-7a2c-09dff8cd4736
+  sha: sha256:15f2276971bbba8c47d86cc82ebfc6ec33e3aef2e4565058b2e4950c07b8e75c
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.7.7  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.7.tar.gz
+HAPROXY_VERSION=2.7.8  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.8.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.7.7 to version 2.7.8, downloaded from https://www.haproxy.org/download/2.7/src/haproxy-2.7.8.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
