### PR TITLE
Bump haproxy version to 2.6.13

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.6.12.tar.gz:
-  size: 4060878
-  object_id: 9366ee5e-9a81-4e5e-504a-a49a6d2a3e6f
-  sha: sha256:58f9edb26bf3288f4b502658399281cc5d6478468bd178eafe579c8f41895854
+haproxy/haproxy-2.6.13.tar.gz:
+  size: 4065839
+  object_id: 33245725-79d4-4d26-6895-27fbf4813e7d
+  sha: sha256:d69ff5233dbca657132ef280d111222ec1e33f5be1c1937d4e9ff516f63f5243
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.6.12  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.12.tar.gz
+HAPROXY_VERSION=2.6.13  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.13.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.6.12 to version 2.6.13, downloaded from https://www.haproxy.org/download/2.6/src/haproxy-2.6.13.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
