### PR TITLE
Bump lua version to 5.4.6

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,10 @@ haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4
   sha: sha256:6ba2136e98b9a436488be67a54a5295f55f38090157d09df0154dda493ac5815
-haproxy/lua-5.4.5.tar.gz:
-  size: 363316
-  object_id: bf3a8555-990a-4da7-5ff8-de9a56f91db4
-  sha: sha256:59df426a3d50ea535a460a452315c4c0d4e1121ba72ff0bdde58c2ef31d6f444
+haproxy/lua-5.4.6.tar.gz:
+  size: 363329
+  object_id: 7b7ffa11-ae22-4fec-5f45-fcef34d8291f
+  sha: sha256:7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
 haproxy/pcre2-10.42.tar.gz:
   size: 2397194
   object_id: 1411549b-cc2b-4140-68d1-f55bc6b17bef

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 
-LUA_VERSION=5.4.5  # https://www.lua.org/ftp/lua-5.4.5.tar.gz
+LUA_VERSION=5.4.6  # https://www.lua.org/ftp/lua-5.4.6.tar.gz
 
 PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 5.4.5 to version 5.4.6, downloaded from https://www.lua.org/ftp/lua-5.4.6.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
