### PR TITLE
ci: remove github-release-alt resource type

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -443,15 +443,6 @@ resource_types:
     source:
       repository: teliaoss/github-pr-resource
 
-  # FIXME: Need to use latest version of this resource due to
-  # https://github.com/concourse/github-release-resource/issues/108
-  # https://github.com/concourse/github-release-resource/pull/107
-  # Until Concourse is updated to 7.5.0+
-  - name: github-release-alt
-    type: registry-image
-    source:
-      repository: concourse/github-release-resource
-
   - name: gcs
     type: docker-image
     source:
@@ -503,7 +494,7 @@ resources:
       url: ((slack.webhook))
 
   - name: github
-    type: github-release-alt
+    type: github-release
     source:
       user:         cloudfoundry
       repository:   haproxy-boshrelease


### PR DESCRIPTION
Check works fine now. No patched resource needed anymore.