### PR TITLE
Bump keepalived version to 2.2.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,7 +18,7 @@ haproxy/socat-1.7.4.4.tar.gz:
   size: 662968
   object_id: 674c1075-b8d9-4b29-5af3-d0d0ed1cbb09
   sha: sha256:0f8f4b9d5c60b8c53d17b60d79ababc4a0f51b3bb6d2bd3ae8a6a4b9d68f195e
-keepalived/keepalived-2.2.7.tar.gz:
-  size: 1180180
-  object_id: c02487cf-d07c-4c46-576d-6ae6bb3ca51f
-  sha: sha256:c61940d874154a560a54627ecf7ef47adebdf832164368d10bf242a4d9b7d49d
+keepalived/keepalived-2.2.8.tar.gz:
+  size: 1202602
+  object_id: ce994b90-fe7b-4563-71f2-a93a515eb5b0
+  sha: sha256:85882eb62974f395d4c631be990a41a839594a7e62fbfebcb5649a937a7a1bb6

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -5,7 +5,7 @@ set -e -x
 mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
-KEEPALIVED_VERSION=2.2.7  # http://www.keepalived.org/software/keepalived-2.2.7.tar.gz
+KEEPALIVED_VERSION=2.2.8  # https://keepalived.org/software/keepalived-2.2.8.tar.gz
 tar xzvf keepalived/keepalived-${KEEPALIVED_VERSION}.tar.gz
 cd keepalived-${KEEPALIVED_VERSION}/
 


### PR DESCRIPTION

Automatic bump from version 2.2.7 to version 2.2.8, downloaded from https://keepalived.org/software/keepalived-2.2.8.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
