### PR TITLE
fix(ci): only trigger ci on approved PRs

### DIFF
--- a/ci/pipeline-haproxy-maintenance.yml
+++ b/ci/pipeline-haproxy-maintenance.yml
@@ -409,6 +409,7 @@ resources:
       repository:   cloudfoundry/haproxy-boshrelease
       base_branch:  maintenance
       labels:       [run-ci]
+      required_review_approvals: 1
 
   - name: stemcell-bionic
     type: bosh-io-stemcell

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -463,6 +463,7 @@ resources:
       repository:   cloudfoundry/haproxy-boshrelease
       base_branch:  master
       labels:       [run-ci]
+      required_review_approvals: 1
 
   - name: stemcell-bionic
     type: bosh-io-stemcell


### PR DESCRIPTION
- CI can now only be triggered with both "run-ci" label and a fresh approval by one of the code owners
- approvals will be revoked on code changes
- tested successfully on https://github.com/cloudfoundry/haproxy-boshrelease/pull/474
- pipeline already patched