### PR TITLE
ci: use trusted_teams for git-pull-requests

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -11,9 +11,10 @@ Credentials and admin access lie with that team. If you have questions or issues
 
 Concourse is used as CI system. There are two main types of tests and various release specific steps, all of which are defined in [pipeline.yml](pipeline.yml).
 
-* `unit-tests` runs a series of unit tests on the Ruby templating based configuration file generators and includes linters for all code and test code.
-* `acceptance-tests` and `acceptance-tests-pr` runs a series of acceptance tests developed in Go.
-  * `acceptance-tests-pr` is executed for each PR that is marked with the `run-ci` label, while
+  * `unit-tests` runs a series of unit tests on the Ruby templating based configuration file generators and includes linters for all code and test code.
+  * `acceptance-tests` and `acceptance-tests-pr` runs a series of acceptance tests developed in Go.
+  * `unit-tests-pr` and `acceptance-tests-pr` are executed for PRs that are marked with the `run-ci` label AND authored by a member of `wg-app-runtime-platform-networking-extensions-approvers` or technical users like `dependabot` or `CFN-CI`.
+  * `unit-tests-pr` and `acceptance-tests-pr` are executed for each approved PR that is marked with the `run-ci` label.
   * `acceptance-tests` is run on new commits to `master`, e.g. after a PR has been merged.
 
 All tests run in Docker. The image `cf-routing.common.repositories.cloud.sap/haproxy-boshrelease-testflight` is a built and cached version of building [`Dockerfile`](Dockerfile).

--- a/ci/pipeline-haproxy-maintenance.yml
+++ b/ci/pipeline-haproxy-maintenance.yml
@@ -378,7 +378,10 @@ resource_types:
   - name: pull-request
     type: docker-image
     source:
-      repository: teliaoss/github-pr-resource
+      repository: cf-routing.common.repositories.cloud.sap/eirini-github-pr-resource
+      tag: latest
+      username: ((docker.username))
+      password: ((docker.password))
 
   # FIXME: Need to use latest version of this resource due to
   # https://github.com/concourse/github-release-resource/issues/108
@@ -410,6 +413,11 @@ resources:
       base_branch:  maintenance
       labels:       [run-ci]
       required_review_approvals: 1
+      trusted_teams:
+        - "wg-app-runtime-platform-networking-extensions-approvers"
+      trusted_users:
+        - "dependabot"
+        - "CFN-CI"
 
   - name: stemcell-bionic
     type: bosh-io-stemcell
@@ -456,4 +464,3 @@ resources:
       stop: 8:00 AM
       location: Europe/Berlin
       interval: 24h
-      

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -441,7 +441,10 @@ resource_types:
   - name: pull-request
     type: docker-image
     source:
-      repository: teliaoss/github-pr-resource
+      repository: cf-routing.common.repositories.cloud.sap/eirini-github-pr-resource
+      tag: latest
+      username: ((docker.username))
+      password: ((docker.password))
 
   - name: gcs
     type: docker-image
@@ -464,6 +467,11 @@ resources:
       base_branch:  master
       labels:       [run-ci]
       required_review_approvals: 1
+      trusted_teams:
+        - "wg-app-runtime-platform-networking-extensions-approvers"
+      trusted_users:
+        - "dependabot"
+        - "CFN-CI"
 
   - name: stemcell-bionic
     type: bosh-io-stemcell


### PR DESCRIPTION
- Add "wg-app-runtime-platform-networking-extensions-approvers" to trusted_teams
- Add dependabot and CFN-CI to trusted_users
in order to trigger CI pipeline for PRs authored by members of the WG or technical users mentioned above without any approvals.