### PR TITLE
Bump haproxy version to 2.6.15

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.6.14.tar.gz:
-  size: 4067797
-  object_id: 8196c6d2-95ae-41fb-680a-1ab3df9fe0b2
-  sha: sha256:bd3dd9fa60391ca09e1225e1ac3163e45be83c3f54f2fd76a30af289cc6e4fd4
+haproxy/haproxy-2.6.15.tar.gz:
+  size: 4074156
+  object_id: a48382d0-6f68-4a1f-6474-c24a90cfe93e
+  sha: sha256:41f8e1695e92fafdffe39690a68993f1a0f5f7f06931a99e9a153f749ea39cfd
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.6.14  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.14.tar.gz
+HAPROXY_VERSION=2.6.15  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.15.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.6.14 to version 2.6.15, downloaded from https://www.haproxy.org/download/2.6/src/haproxy-2.6.15.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
