### PR TITLE
Release note for 12.2.0 (HAProxy 2.7.10)

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,11 @@
+# Fixes
+No fixes. Version bumps may contain fixes.
+
+# New Features
+No new features.
+
+# Upgrades
+- `haproxy` has been upgraded from v2.7.7 to v2.7.10
+- `lua` has been upgraded from v5.4.4 to v5.4.6
+- `keepalived` has been upgraded from v2.2.7 to v2.2.8
+- Various bumps for the CI environment that did not impact the resulting boshrelease.


### PR DESCRIPTION
Add a release note for 12.2.0 (HAProxy 2.7.10) and other version bumps.