### PR TITLE
ci(pipeline): use the GitHub token for git checkouts

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -456,9 +456,10 @@ resources:
   - name: git
     type: git
     source:
-      uri:         git@github.com:cloudfoundry/haproxy-boshrelease.git
+      uri:         https://github.com/cloudfoundry/haproxy-boshrelease
       branch:      master
-      private_key: ((github.private_key))
+      username:    ((github.bot_user))
+      password:    ((github.access_token))
 
   - name: git-pull-requests
     type: pull-request


### PR DESCRIPTION
Use the GitHub token instead of an SSH key for the `git` resource.

This is already active on the pipeline.