### PR TITLE
refactor: fix parameter order in create_pull according to PyGithub 2.1.X

### DIFF
--- a/ci/scripts/autobump-dependencies.py
+++ b/ci/scripts/autobump-dependencies.py
@@ -208,10 +208,11 @@ class Dependency:
             )
 
             pr = self.remote_repo.create_pull(
-                title=f"Bump {self.name} version to {self.latest_release.version}",
-                body=pr_body,
                 base=PR_BASE,
                 head=f"{PR_ORG}:{self.pr_branch}",
+                title=f"Bump {self.name} version to {self.latest_release.version}",
+                body=pr_body,
+                draft=False,
             )
             pr.add_to_labels(PR_LABEL)
             print(f"[{self.name}] Created Pull Request: {pr.html_url}")


### PR DESCRIPTION
Due to bump of pygithub from 1.59.1 to 2.1.1, the call of create_pull should be adapted. See breaking change in release notes for pygithub for more reference. 

new function signature for create_pull:
`def create_pull(self, base, head, *, title=NotSet, body=NotSet, maintainer_can_modify=NotSet, draft=NotSet, issue=NotSet)`