### PR TITLE
Bump haproxy version to 2.8.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.7.10.tar.gz:
-  size: 4191948
-  object_id: a9f35bd4-348f-4769-5fda-fcbd3882054c
-  sha: sha256:be175dcc1f6ad7ea174262493839bf2e632a3dd7df137dcca4ab882ae00c7490
+haproxy/haproxy-2.8.3.tar.gz:
+  size: 4350288
+  object_id: 291746fe-d1b1-4b91-7746-155dbf0a7579
+  sha: sha256:9ecc6ffe67a977d1ed279107bbdab790d73ae2a626bc38eee23fa1f6786a759e
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.7.10  # https://www.haproxy.org/download/2.7/src/haproxy-2.7.10.tar.gz
+HAPROXY_VERSION=2.8.3  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.3.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.7.10 to version 2.8.3, downloaded from https://www.haproxy.org/download/2.8/src/haproxy-2.8.3.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
