### PR TITLE
ci(autobump): allow haproxy 2.7 on maintenance branch

### DIFF
--- a/ci/scripts/autobump-dependencies.py
+++ b/ci/scripts/autobump-dependencies.py
@@ -390,7 +390,7 @@ def main() -> None:
         HaproxyDependency(
             "haproxy",
             "HAPROXY_VERSION",
-            "2.6",
+            "2.7",
             "https://www.haproxy.org/download/{}/src",
         ),
         WebLinkDependency(


### PR DESCRIPTION
Allow to update haproxy 2.7 on maintenance branch 