### PR TITLE
refactor: use host_only converter

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -445,7 +445,7 @@ frontend https-in
     # Ensure a host header exists to check against
     http-request deny deny_status 400 content-type text/plain string "400 Bad Request: missing required Host header" if { req.hdr_cnt(host) eq 0 }
     # Ignore optional port in Host header when comparing to SNI
-    http-request set-var(txn.host) hdr(host),field(1,:),lower
+    http-request set-var(txn.host) hdr(host),host_only
     acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0
     <%- if disable_domain_fronting  == 'mtls_only' %>
     http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match
@@ -615,7 +615,7 @@ frontend wss-in
     # Ensure a host header exists to check against
     http-request deny deny_status 400 content-type text/plain string "400 Bad Request: missing required Host header" if { req.hdr_cnt(host) eq 0 }
     # Ignore optional port in Host header when comparing to SNI
-    http-request set-var(txn.host) hdr(host),field(1,:),lower
+    http-request set-var(txn.host) hdr(host),host_only
     acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0
     <%- if disable_domain_fronting  == 'mtls_only' %>
     http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -56,7 +56,7 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
 
     it 'disables domain fronting by checking SNI against the Host header' do
-      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),host_only')
       expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_https).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match')
     end
@@ -68,7 +68,7 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
 
     it 'disables domain fronting by checking SNI against the Host header for mtls connections only' do
-      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),host_only')
       expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_https).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match')
     end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -58,7 +58,7 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
 
     it 'disables domain fronting by checking SNI against the Host header' do
-      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),host_only')
       expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_wss).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match')
     end
@@ -70,7 +70,7 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
 
     it 'disables domain fronting by checking SNI against the Host header for mtls connections only' do
-      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),host_only')
       expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_wss).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match')
     end


### PR DESCRIPTION
Previously we manually converted the host header by splitting it on the colon and making it lower case.

This commit switches to the host_only sample which is meant to do exactly that.

See: https://docs.haproxy.org/2.6/configuration.html#7.3.1-host_only