### PR TITLE
Create release_notes for 13.3.0

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,11 @@
+# Fixes
+- Fixes sporadic HTTP/2 issues: https://github.com/cloudfoundry/haproxy-boshrelease/issues/571
+
+# New Features
+- none
+
+# Upgrades
+- `HAProxy` has been upgraded from v2.8.3 to v2.8.4
+
+# Remarks
+- haproxy-boshrelease v13.2.0 was skipped due to issues within the CI

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -9,3 +9,4 @@
 
 # Remarks
 - haproxy-boshrelease v13.2.0 was skipped due to issues within the CI
+- HTTP/2 requests that would be hit by https://github.com/cloudfoundry/haproxy-boshrelease/issues/571, will be successful but the access log writes `SD--`


### PR DESCRIPTION
Same content like in https://github.com/cloudfoundry/haproxy-boshrelease/pull/572.

Docker on the CI had some issues resolving github and could not push. After a retry, the docker container was also cleaned up. To reduce the efforts, we simply create a new release (after fixing the DNS issues)