### PR TITLE
Bump haproxy version to 2.8.5

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.8.4.tar.gz:
-  size: 4361756
-  object_id: a0c1bd44-c329-41ea-4a23-b7339388714f
-  sha: sha256:81bacbf50ec6d0f7ecaaad7c03e59978b00322fbdad6ed4a989dd31754b6f25d
+haproxy/haproxy-2.8.5.tar.gz:
+  size: 4364802
+  object_id: bb0fdcd5-8ba8-4b2f-48ce-70a6839f0fb4
+  sha: sha256:3f5459c5a58e0b343a32eaef7ed5bed9d3fc29d8aa9e14b36c92c969fc2a60d9
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.8.4  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.4.tar.gz
+HAPROXY_VERSION=2.8.5  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.5.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.8.4 to version 2.8.5, downloaded from https://www.haproxy.org/download/2.8/src/haproxy-2.8.5.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
