### PR TITLE
feat: Enable redispatch to different server on retry

### DIFF
--- a/acceptance-tests/retry_redispatch_test.go
+++ b/acceptance-tests/retry_redispatch_test.go
@@ -1,0 +1,95 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Retry and Redispatch Tests", func() {
+	var haproxyInfo haproxyInfo
+	var closeTunnel []func()
+	var closeLocalServer []func()
+
+	enableRedispatch := false
+	haproxyBackendPort := 12000
+	haproxyBackendHealthPort := 8080
+	opsfileRetry := `---
+# Configure Redispatch
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/enable_redispatch?
+  value: ((enable_redispatch))
+# Configure Retries
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/retries?
+  value: 2
+# Enable backend http health check
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/backend_use_http_health?
+  value: true
+`
+
+	JustBeforeEach(func() {
+		haproxyInfo, _ = deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1", "127.0.0.2"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileRetry}, map[string]interface{}{
+			"enable_redispatch": enableRedispatch,
+		}, true)
+
+		setupTunnel := func(ip string, backendPort int) {
+			closeLocalServerFunc, localPort := startDefaultTestServer(withIP(ip))
+			closeTunnelFunc := setupTunnelFromHaproxyIPToTestServerIP(haproxyInfo, ip, backendPort, ip, localPort)
+
+			closeTunnel = append(closeTunnel, closeTunnelFunc)
+			closeLocalServer = append(closeLocalServer, closeLocalServerFunc)
+		}
+
+		setupTunnel("127.0.0.1", haproxyBackendPort)
+		setupTunnel("127.0.0.1", haproxyBackendHealthPort)
+
+		setupTunnel("127.0.0.2", haproxyBackendHealthPort) // this backend seems healthy but does not respond to traffic
+	})
+
+	AfterEach(func() {
+		for _, closeLocalServerFunc := range closeLocalServer {
+			closeLocalServerFunc()
+		}
+		for _, closeTunnelFunc := range closeTunnel {
+			closeTunnelFunc()
+		}
+	})
+
+	Context("When ha_proxy.enable_redispatch is false (default)", func() {
+		BeforeEach(func() {
+			enableRedispatch = false
+		})
+
+		It("Does not redispatch by default", func() {
+			By("Sending a request to broken backend results in a 503")
+
+			Eventually(func() int {
+				resp, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+				Expect(err).NotTo(HaveOccurred())
+				return resp.StatusCode
+			}).Should(Equal(http.StatusServiceUnavailable))
+		})
+	})
+	Context("When ha_proxy.enable_redispatch is true", func() {
+		BeforeEach(func() {
+			enableRedispatch = true
+		})
+
+		It("Does redispatch to other backends", func() {
+			By("Sending a request to broken backend results in a 200 due to redispatch to working backend")
+
+			Consistently(func() int {
+				resp, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+				Expect(err).NotTo(HaveOccurred())
+				return resp.StatusCode
+			}).Should(Equal(http.StatusOK))
+		})
+	})
+})

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -258,6 +258,12 @@ properties:
   ha_proxy.disable_backend_http2_websockets:
     default: false
     description: "Forward websockets to the backend servers using HTTP/1.1, never HTTP/2. Does not apply to custom routed_backend_servers. Works around https://github.com/cloudfoundry/routing-release/issues/230. Overrides backend_match_http_protocol for websockets."
+  ha_proxy.enable_redispatch:
+    default: false
+    description: "When enabled, HAProxy will try to connect to another server if a connect attempt fails. Best used in conjunction with retries."
+  ha_proxy.retries:
+    default: 0
+    description: "HAProxy will retry this many times on failed connections. When redispatch is enabled, the retries may occur on different servers. In combination with connect_timeout this defines the maximum response time of HAProxy to clients. e.g. 0.5s connect_timeout * 10 retries = 5s max response time"
 
   ha_proxy.connect_timeout:
     description: "Timeout (in floating point seconds) used on connections from haproxy to a backend, while waiting for the TCP handshake to complete + connection to establish"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -172,6 +172,10 @@ end
     abort "Conflicting configuration: if enable_4443 is true, you must provide a valid SSL config via ssl_pem or crt_list"
   end
 
+  if p("ha_proxy.retries") == 0 && p("ha_proxy.enable_redispatch")
+    abort "Conflicting configuration: enable_redispatch works only with retries > 0"
+  end
+
   backend_servers = []
   backend_servers_local = []
   backend_port = nil
@@ -281,6 +285,13 @@ defaults
   <%- if p("ha_proxy.backend_prefer_local_az") -%>
     option allbackups
   <%- end -%>
+  <%- if p("ha_proxy.enable_redispatch") -%>
+    option redispatch
+  <%- end -%>
+  <%- if p("ha_proxy.retries") > 0 -%>
+    retries <%= p("ha_proxy.retries") %>
+  <%- end -%>
+
     timeout connect         <%= (p("ha_proxy.connect_timeout").to_f    * 1000).to_i %>ms
     timeout client          <%= (p("ha_proxy.client_timeout").to_f     * 1000).to_i %>ms
     timeout server          <%= (p("ha_proxy.server_timeout").to_f     * 1000).to_i %>ms

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -432,4 +432,30 @@ describe 'config/haproxy.config global and default options' do
       expect(global).to include('h1-accept-payload-with-any-method')
     end
   end
+
+  context 'when ha_proxy.enable_redispatch is true but retries missing' do
+    let(:properties) do
+      {
+        'enable_redispatch' => true
+      }
+    end
+
+    it 'throws an error because retries are missing' do
+      expect { defaults }.to raise_error(/Conflicting configuration: enable_redispatch works only with retries > 0/)
+    end
+  end
+
+  context 'when ha_proxy.enable_redispatch is true and retries are enabled' do
+    let(:properties) do
+      {
+        'enable_redispatch' => true,
+        'retries' => 1
+      }
+    end
+
+    it 'enables redispatching in the default section and sets retries' do
+      expect(defaults).to include('option redispatch')
+      expect(defaults).to include('retries 1')
+    end
+  end
 end


### PR DESCRIPTION
Without retries and redispatch enabled, failing backends produce an outage to the client.
The redispatch option allows HAProxy to try another backend instead of failing the request.

- Adds the option to retry failed connections to backends
- Adds the option to redispatch to other backends on failed connects
- Checks that retries are configured if redispatch is enabled

- Also, the test framework was updated so that it supports more than one backend per HAProxy.