### PR TITLE
Bump pcre2 version to 10.43

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,10 @@ haproxy/lua-5.4.6.tar.gz:
   size: 363329
   object_id: 7b7ffa11-ae22-4fec-5f45-fcef34d8291f
   sha: sha256:7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
-haproxy/pcre2-10.42.tar.gz:
-  size: 2397194
-  object_id: 1411549b-cc2b-4140-68d1-f55bc6b17bef
-  sha: sha256:c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f
+haproxy/pcre2-10.43.tar.gz:
+  size: 2522928
+  object_id: b712245c-72ec-43bb-462c-b15e2fbe7f07
+  sha: sha256:889d16be5abb8d05400b33c25e151638b8d4bac0e2d9c76e9d6923118ae8a34e
 haproxy/socat-1.7.4.4.tar.gz:
   size: 662968
   object_id: 674c1075-b8d9-4b29-5af3-d0d0ed1cbb09

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 LUA_VERSION=5.4.6  # https://www.lua.org/ftp/lua-5.4.6.tar.gz
 
-PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.gz
+PCRE_VERSION=10.43  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.43/pcre2-10.43.tar.gz
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 10.42 to version 10.43, downloaded from https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.43/pcre2-10.43.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
