### PR TITLE
fix: only skip PRs not regular acceptance tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -190,7 +190,7 @@ jobs:
           path: git-pull-requests
           status: pending
           context: acceptance-tests
-        get_params: 
+        get_params:
           list_changed_files: true
       - task: acceptance-tests
         privileged: true

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -20,13 +20,14 @@ git submodule update --init --recursive --force
 
 # shellcheck disable=SC1091
 source "ci/scripts/skip-ci.sh"
-if skip_ci "ci/.ci-ignore" ".git/resource/changed_files"; then
-  echo "SKIP TEST: Only .ci-ignored changes found."
-  exit 0
-else
-  echo "RUN TEST: There is at least one non-ignored change found."
+if [ -f ".git/resource/changed_files" ]; then
+  if skip_ci "ci/.ci-ignore" ".git/resource/changed_files"; then
+    echo "SKIP TEST: Only .ci-ignored changes found."
+    exit 0
+  else
+    echo "RUN TEST: There is at least one non-ignored change found."
+  fi
 fi
-
 echo "----- Starting BOSH"
 
 ./ci/scripts/start-bosh.sh


### PR DESCRIPTION
the `.git/resource/changed_files` file exists only on PRs