### PR TITLE
Bump haproxy version to 2.8.9

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.8.7.tar.gz:
-  size: 4376705
-  object_id: a02cc1e3-6513-4357-5e52-31a3f2406b2e
-  sha: sha256:0d1a61161789c8ec50662955deffba50ab4ebe7efc6c0d947ff570ee7098e7f8
+haproxy/haproxy-2.8.9.tar.gz:
+  size: 4383096
+  object_id: 95357784-6a57-4112-47a2-9590af64135d
+  sha: sha256:7a821478f36f847607f51a51e80f4f890c37af4811d60438e7f63783f67592ff
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.43  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.8.7  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.7.tar.gz
+HAPROXY_VERSION=2.8.9  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.9.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.8.7 to version 2.8.9, downloaded from https://www.haproxy.org/download/2.8/src/haproxy-2.8.9.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
