### PR TITLE
ci: use ssh key for CFN-CI bot in concourse pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -458,10 +458,10 @@ resources:
   - name: git
     type: git
     source:
-      uri:         https://github.com/cloudfoundry/haproxy-boshrelease
+      uri:         git@github.com:cloudfoundry/haproxy-boshrelease.git
       branch:      master
-      username:    ((github.bot_user))
-      password:    ((github.access_token))
+      private_key_user:    ((github.bot_user))
+      private_key:         ((github.bot_deploy_key_private))
 
   - name: git-pull-requests
     type: pull-request


### PR DESCRIPTION
Problem:
It is not possible for the CFN-CI bot to bypass the branch protection rules. This is due to the fact that this user is no admin on this repo here.

Solution
Make use of a deploy key added to this repo within the git-resources.