### PR TITLE
Bump haproxy version to 2.8.10

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.8.9.tar.gz:
-  size: 4383096
-  object_id: 95357784-6a57-4112-47a2-9590af64135d
-  sha: sha256:7a821478f36f847607f51a51e80f4f890c37af4811d60438e7f63783f67592ff
+haproxy/haproxy-2.8.10.tar.gz:
+  size: 4392333
+  object_id: 82d52729-5e18-41f1-4b3b-31f7de3e2a42
+  sha: sha256:0d63cd46d9d10ac7dbc02f3c6769c1908f221e0a5c5b655a194655f7528d612a
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.43  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.8.9  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.9.tar.gz
+HAPROXY_VERSION=2.8.10  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.10.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.8.9 to version 2.8.10, downloaded from https://www.haproxy.org/download/2.8/src/haproxy-2.8.10.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
