### PR TITLE
Add strip_header to delete headers on the frontend

### DIFF
--- a/acceptance-tests/headers_test.go
+++ b/acceptance-tests/headers_test.go
@@ -1,0 +1,143 @@
+package acceptance_tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Headers", func() {
+	opsfileHeaders := `---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/strip_headers?
+  value: ["Custom-Header-To-Delete", "Custom-Header-To-Replace"]
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/headers?
+  value: 
+    Custom-Header-To-Add: add-value
+    Custom-Header-To-Replace: replace-value
+# Configure CA and cert chain
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/crt_list?/-
+  value:
+    snifilter:
+    - haproxy.internal
+    ssl_pem:
+      cert_chain: ((https_frontend.certificate))((https_frontend_ca.certificate))
+      private_key: ((https_frontend.private_key))
+# Declare certs
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: bosh
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend
+    type: certificate
+    options:
+      ca: https_frontend_ca
+      common_name: haproxy.internal
+      alternative_names: [haproxy.internal]
+`
+	var closeLocalServer func()
+	var creds struct {
+		HTTPSFrontend struct {
+			Certificate string `yaml:"certificate"`
+			PrivateKey  string `yaml:"private_key"`
+			CA          string `yaml:"ca"`
+		} `yaml:"https_frontend"`
+	}
+	var client *http.Client
+	var recordedHeaders http.Header
+	var request *http.Request
+
+	It("Check correct headers handling", func() {
+		haproxyBackendPort := 12000
+		var varsStoreReader varsStoreReader
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileHeaders}, map[string]interface{}{}, true)
+
+		err := varsStoreReader(&creds)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Starting a local http server to act as a backend")
+		var localPort int
+		closeLocalServer, localPort, err = startLocalHTTPServer(nil, func(w http.ResponseWriter, r *http.Request) {
+			writeLog("Backend server handling incoming request")
+			recordedHeaders = r.Header
+			_, _ = w.Write([]byte("OK"))
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+		client = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
+			[]tls.Certificate{}, "",
+		)
+
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// These headers are sent to HAProxy during the test
+		headersToSend := map[string]string{
+			"Custom-Header-To-Replace": "old-value",
+			"Custom-Header-To-Delete":  "some-value",
+		}
+
+		for key, value := range headersToSend {
+			request.Header.Set(key, value)
+		}
+
+		// These headers are expected to be removed by HAProxy,
+		// as the header keys are defined in 'strip_headers' (see `opsfileHeaders`).
+		headerKeysNotToExpect := []string{"Custom-Header-To-Delete"}
+
+		// These headers are expected to be set by HAProxy,
+		// as they are defined in 'headers' (see `opsfileHeaders`).
+		headersWithKeysToExpect := map[string]string{
+			"Custom-Header-To-Add":     "add-value",
+			"Custom-Header-To-Replace": "replace-value",
+		}
+
+		// These headers are expected to be set by HAProxy with another value,
+		// as they are defined in 'strip_headers' and `headers` (see `opsfileHeaders`).
+		headersWithKeysNotToExpect := map[string]string{
+			"Custom-Header-To-Replace": "old-value",
+		}
+
+		By("Gets successful request")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+
+		By("Correctly removes headers in 'strip_headers'")
+		for headerKey := range headerKeysNotToExpect {
+			Expect(recordedHeaders).NotTo(HaveKey(headerKey))
+		}
+
+		By("Correctly adds headers in 'headers'")
+		for headerKey, headerValue := range headersWithKeysToExpect {
+			Expect(recordedHeaders).To(HaveKey(headerKey))
+			Expect(recordedHeaders[headerKey]).To(ContainElements(headerValue))
+		}
+
+		By("Correctly replaces the value in 'strip_headers' when 'headers' with same key is present")
+		for headerKey, headerValue := range headersWithKeysNotToExpect {
+			Expect(recordedHeaders).To(HaveKey(headerKey))
+			Expect(recordedHeaders[headerKey]).NotTo(ContainElements(headerValue))
+		}
+
+	})
+})

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -383,6 +383,13 @@ properties:
           backend_health_rise: 2  # optional, ignored if backend_use_http_health is false. Defaults to 2 if not set. Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state.
           additional_acls: ["method GET"] # optional, defaults to []. Include additional ACLs that are required for this backend to be used. ACLs are combined with logical AND
 
+  ha_proxy.strip_headers:
+    description: "List of custom headers to delete on each request. Spaces are automatically escaped, but any other haproxy delimiters will need to be escaped manually"
+    example: |
+      strip_headers:
+        - MyHeader
+        - MyCustomHeaderToDelete
+
   ha_proxy.headers:
     description: "Hash of custom headers you wish you have set on each request. Spaces are automatically escaped, but any other haproxy delimiters will need to be escaped manually"
     example: |

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -437,6 +437,11 @@ frontend http-in
     http-request deny if <%= acl_names %>
     <%- end -%>
   <%- end -%>
+  <%- if_p("ha_proxy.strip_headers") do |headers| -%>
+    <%- headers.each do |header| -%>
+     http-request del-header <%= header.gsub(/(?!:\\)( )/, '\ ') %>
+    <%- end -%>
+  <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
     http-request add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
@@ -611,6 +616,11 @@ frontend https-in
     http-request deny if <%= acl_names %>
     <%- end -%>
   <%- end -%>
+  <%- if_p("ha_proxy.strip_headers") do |strip_headers| -%>
+    <%- strip_headers.each do |strip_header| -%>
+    http-request del-header <%= strip_header.gsub(/(?!:\\)( )/, '\ ') %>
+    <%- end -%>
+  <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
     http-request add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
@@ -767,6 +777,11 @@ frontend wss-in
         <%- end -%>
       <%- end -%>
     http-request deny if <%= acl_names %>
+    <%- end -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.strip_headers") do |headers| -%>
+    <%- headers.each do |header| -%>
+      http-request del-header <%= header.gsub(/(?!:\\)( )/, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -149,6 +149,32 @@ describe 'config/haproxy.config HTTP frontend' do
     end
   end
 
+  context 'when ha_proxy.strip_headers are provided' do
+    let(:properties) do
+      { 'strip_headers' => %w[MyHeader MySecondHeader] }
+    end
+
+    it 'deletes the headers' do
+      expect(frontend_http).to include('http-request del-header MyHeader')
+      expect(frontend_http).to include('http-request del-header MySecondHeader')
+    end
+  end
+
+  context 'when ha_proxy.strip_headers and ha_proxy.headers are provided' do
+    let(:properties) do
+      {
+        'strip_headers' => %w[MyHeader MySecondHeader],
+        'headers' => ['MyHeader: my-custom-header']
+      }
+    end
+
+    it 'contains the headers' do
+      expect(frontend_http).to include('http-request del-header MyHeader')
+      expect(frontend_http).to include('http-request del-header MySecondHeader')
+      expect(frontend_http).to include('http-request add-header MyHeader:\ my-custom-header ""')
+    end
+  end
+
   context 'when ha_proxy.headers are provided' do
     let(:properties) do
       { 'headers' => ['X-Application-ID: my-custom-header', 'MyCustomHeader: 3'] }

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -538,6 +538,32 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
   end
 
+  context 'when ha_proxy.strip_headers are provided' do
+    let(:properties) do
+      default_properties.merge({ 'strip_headers' => %w[MyHeader MySecondHeader] })
+    end
+
+    it 'deletes the headers' do
+      expect(frontend_https).to include('http-request del-header MyHeader')
+      expect(frontend_https).to include('http-request del-header MySecondHeader')
+    end
+  end
+
+  context 'when ha_proxy.strip_headers and ha_proxy.headers are provided' do
+    let(:properties) do
+      default_properties.merge({
+        'strip_headers' => %w[MyHeader MySecondHeader],
+        'headers' => ['MyHeader: my-custom-header']
+      })
+    end
+
+    it 'contains the headers' do
+      expect(frontend_https).to include('http-request del-header MyHeader')
+      expect(frontend_https).to include('http-request del-header MySecondHeader')
+      expect(frontend_https).to include('http-request add-header MyHeader:\ my-custom-header ""')
+    end
+  end
+
   context 'when ha_proxy.headers are provided' do
     let(:properties) do
       default_properties.merge({ 'headers' => ['X-Application-ID: my-custom-header', 'MyCustomHeader: 3'] })

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -565,6 +565,32 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
   end
 
+  context 'when ha_proxy.strip_headers are provided' do
+    let(:properties) do
+      default_properties.merge({ 'strip_headers' => %w[MyHeader MySecondHeader] })
+    end
+
+    it 'deletes the headers' do
+      expect(frontend_wss).to include('http-request del-header MyHeader')
+      expect(frontend_wss).to include('http-request del-header MySecondHeader')
+    end
+  end
+
+  context 'when ha_proxy.strip_headers and ha_proxy.headers are provided' do
+    let(:properties) do
+      default_properties.merge({
+        'strip_headers' => %w[MyHeader MySecondHeader],
+        'headers' => ['MyHeader: my-custom-header']
+      })
+    end
+
+    it 'contains the headers' do
+      expect(frontend_wss).to include('http-request del-header MyHeader')
+      expect(frontend_wss).to include('http-request del-header MySecondHeader')
+      expect(frontend_wss).to include('http-request add-header MyHeader:\ my-custom-header ""')
+    end
+  end
+
   context 'when ha_proxy.headers are provided' do
     let(:properties) do
       default_properties.merge({ 'headers' => ['X-Application-ID: my-custom-header', 'MyCustomHeader: 3'] })


### PR DESCRIPTION
Implement config property strip_headers, which allows to delete configured headers from incoming requests based on the header key.

If both 'strip_headers' and 'headers' contain the same key, the header (if set) is first deleted from the request, and then set to the configured value.