### PR TITLE
Bump keepalived version to 2.3.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,7 +18,7 @@ haproxy/socat-1.8.0.0.tar.gz:
   size: 712469
   object_id: 0414b64a-b098-4994-54a8-95453116e38e
   sha: sha256:6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
-keepalived/keepalived-2.2.8.tar.gz:
-  size: 1202602
-  object_id: ce994b90-fe7b-4563-71f2-a93a515eb5b0
-  sha: sha256:85882eb62974f395d4c631be990a41a839594a7e62fbfebcb5649a937a7a1bb6
+keepalived/keepalived-2.3.1.tar.gz:
+  size: 1210697
+  object_id: a4e911bc-924f-4837-6760-87ecc1217ba0
+  sha: sha256:92f4b69bfd998e2306d1995ad16fdad1b59e70be694c883385c5f55e02c62aa3

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -5,7 +5,7 @@ set -e -x
 mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
-KEEPALIVED_VERSION=2.2.8  # https://keepalived.org/software/keepalived-2.2.8.tar.gz
+KEEPALIVED_VERSION=2.3.1  # https://keepalived.org/software/keepalived-2.3.1.tar.gz
 tar xzvf keepalived/keepalived-${KEEPALIVED_VERSION}.tar.gz
 cd keepalived-${KEEPALIVED_VERSION}/
 


### PR DESCRIPTION

Automatic bump from version 2.2.8 to version 2.3.1, downloaded from https://keepalived.org/software/keepalived-2.3.1.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
