### PR TITLE
Create release_notes for v14.3.0+2.8.10

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,2 @@
+# Upgrades
+- `keepalived` has been upgraded from v2.2.8 to v2.3.1


### PR DESCRIPTION
According to versioning guide: https://github.com/cloudfoundry/haproxy-boshrelease/tree/master/ci#versioning-guide