### PR TITLE
Adding option to check backend health via TLS

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -677,7 +677,9 @@ properties:
   ha_proxy.backend_health_rise:
     description: Number of consecutive successful health checks required before the server is considered healthy from an unhealthy state. The default value of 2 matches the default if the parameter is undefined. This parameter will be ignored if ha_proxy.backend_use_http_health is false.
     default: 2
-
+  ha_proxy.backend_https_check:
+    description: Set to true if the backend uses TLS on the health endpoint. Adds the check-ssl option to the backend configs. If backend certificate on traffic port is verified the Health endpoint cert will also be verified.  
+    default: false
   ha_proxy.global_config:
     description: |
       Raw HAProxy config that will be added to the HA proxy global section, provided either as a multiline text blob or as an array of lines.

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -680,6 +680,7 @@ properties:
   ha_proxy.backend_https_check:
     description: Set to true if the backend uses TLS on the health endpoint. Adds the check-ssl option to the backend configs. If backend certificate on traffic port is verified the Health endpoint cert will also be verified.  
     default: false
+    
   ha_proxy.global_config:
     description: |
       Raw HAProxy config that will be added to the HA proxy global section, provided either as a multiline text blob or as an array of lines.

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -856,9 +856,11 @@ backend <%= backend[:name] %>
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
     <%- health_check_options += " fall " + p("ha_proxy.backend_health_fall").to_s -%>
     <%- health_check_options += " rise " + p("ha_proxy.backend_health_rise").to_s -%>
+    <%- p("ha_proxy.backend_https_check") ? ssl_check = " check-ssl" : ssl_check = nil -%>
   <%- end -%>
+
   <% backend_servers.each_with_index do |ip, index| %>
-    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend[:backend_ssl] %><%= backend[:alpn] %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip)  -%> backup<%- end -%>
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check<%= ssl_check -%> inter 1000 <%= health_check_options %> <%= backend[:backend_ssl] %><%= backend[:alpn] %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip)  -%> backup<%- end -%>
   <% end %>
 # }}}
 <%- end %>

--- a/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
@@ -146,6 +146,26 @@ describe 'config/haproxy.config backend http-routers' do
         expect(backend_http1).to include('server node1 10.0.0.2:80 check inter 1000 port 8080 fall 3 rise 99')
       end
     end
+
+    context 'when tls health checks for backend are enabled' do
+      let(:properties) do
+        {
+          'backend_use_http_health' => true,
+          'backend_http_health_uri' => '1.2.3.5/health',
+          'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+          'backend_https_check' => true
+        }
+      end
+
+      it 'configures the healthcheck' do
+        expect(backend_http1).to include('option httpchk GET 1.2.3.5/health')
+      end
+
+      it 'configures the servers' do
+        expect(backend_http1).to include('server node0 10.0.0.1:80 check check-ssl inter 1000 port 8080 fall 3 rise 2')
+        expect(backend_http1).to include('server node1 10.0.0.2:80 check check-ssl inter 1000 port 8080 fall 3 rise 2')
+      end
+    end
   end
 
   context 'when backend servers are provided via ha_proxy.backend_servers' do


### PR DESCRIPTION
Hello haproxy people,

CF Gorouter wants to switch to TLS healthchecks. I tested out if the HAProxy works with it. I found the issue that unless you tell it explicitly to only use TLS for health checks it will run into TLS issues (namely not using it). THis PR aims to add an option to enable check-ssl (https://docs.haproxy.org/2.4/configuration.html#5.2-check-ssl) to the release.

I tested it working by hand originally on our staging and made a PR to replicate the setup with the bosh release. The Linter and test suite are green and without complaints. I also added a simple test for the property.

