### PR TITLE
Bump socat version to 1.8.0.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,10 +14,10 @@ haproxy/pcre2-10.44.tar.gz:
   size: 2552792
   object_id: 7c730529-4f0e-4503-516b-8d7a46186f73
   sha: sha256:86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b
-haproxy/socat-1.8.0.0.tar.gz:
-  size: 712469
-  object_id: 0414b64a-b098-4994-54a8-95453116e38e
-  sha: sha256:6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82
+haproxy/socat-1.8.0.1.tar.gz:
+  size: 723747
+  object_id: 844e5815-87e6-460a-7cd2-7fbd52d415c3
+  sha: sha256:dc350411e03da657269e529c4d49fe23ba7b4610b0b225c020df4cf9b46e6982
 keepalived/keepalived-2.3.1.tar.gz:
   size: 1210697
   object_id: a4e911bc-924f-4837-6760-87ecc1217ba0

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -6,7 +6,7 @@ LUA_VERSION=5.4.7  # https://www.lua.org/ftp/lua-5.4.7.tar.gz
 
 PCRE_VERSION=10.44  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.gz
 
-SOCAT_VERSION=1.8.0.0  # http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz
+SOCAT_VERSION=1.8.0.1  # http://www.dest-unreach.org/socat/download/socat-1.8.0.1.tar.gz
 
 HAPROXY_VERSION=2.8.10  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.10.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 1.8.0.0 to version 1.8.0.1, downloaded from http://www.dest-unreach.org/socat/download/socat-1.8.0.1.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
