### PR TITLE
fix: docker startup in acceptance

### DIFF
--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -139,7 +139,6 @@ function start_docker() {
 }
 EOF
 
-  trap stop_docker ERR
   service docker start
 
   export DOCKER_TLS_VERIFY=1
@@ -162,6 +161,7 @@ EOF
     exit 1
   fi
 
+  trap stop_docker ERR
   echo $certs_dir
 }
 

--- a/ci/scripts/start-bosh.sh
+++ b/ci/scripts/start-bosh.sh
@@ -145,19 +145,23 @@ EOF
   export DOCKER_CERT_PATH=$1
 
   rc=1
-  for i in $(seq 1 100); do
+  for i in $(seq 1 10); do
     echo waiting for docker to come up...
-    sleep 1
+    sleep 10
     set +e
     docker info
     rc=$?
     set -e
     if [ "$rc" -eq "0" ]; then
-        break
+      break
+    else
+      service docker restart
+      sleep 20
     fi
   done
 
   if [ "$rc" -ne "0" ]; then
+    echo "Failed starting docker. Exiting."
     exit 1
   fi
 


### PR DESCRIPTION
Do not set -e, because then we trap service docker stop and docker never starts. Instead keep waiting.