### PR TITLE
fix(expect-proxy): provide alternative health endpoint for expect_proxy_cidrs

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -225,7 +225,7 @@ properties:
     description: "The HAProxy health check endpoint returns a healthy status if at least one backend server is responding. By default when enable_health_check_http: true, Bosh will consider the HAProxy VM unhealthy if the HAProxy health check returns an unhealthy status. In some cases this might not be desired, for example when deploying HAProxy before deploying the backend servers. To prevent Bosh from considering the HAProxy VM unhealthy when all backend servers are unhealthy set disable_monit_health_check_http: true. Note that this flag is ignored unless enable_health_check_http: true."
     default: false
   ha_proxy.health_check_port:
-    description: "port for http health-check"
+    description: "port for http health-check. Please note that `health_check_port` + 1 (e.g. 8081) is used with the `accept-proxy` directive, if `expect_proxy_cidrs` are defined. You will need to direct your health checker to the appropriate port (with or without Proxy Protocol) for correct functionality."
     default: 8080
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -365,14 +365,20 @@ listen health_check_http_url
     <%- if p("ha_proxy.accept_proxy") && !p("ha_proxy.disable_health_check_proxy") -%>
     tcp-request connection expect-proxy layer4 unless LOCALHOST
     <%- end -%>
-    <%- if p("ha_proxy.expect_proxy_cidrs", []).size > 0 -%>
-      <%- if !p("ha_proxy.disable_health_check_proxy") -%>
-    tcp-request connection expect-proxy layer4 if { src -f /var/vcap/jobs/haproxy/config/expect_proxy_cidrs.txt }
-      <%- end -%>
-    <%- end -%>
+
+    acl http-routers_down nbsrv(<%= backends.first[:name] %>) eq 0
+    monitor fail if http-routers_down
+
+<%- if p("ha_proxy.expect_proxy_cidrs", []).size > 0 -%>
+listen health_check_http_url_proxy_protocol
+    bind :<%= p("ha_proxy.health_check_port") + 1 %> accept-proxy
+    mode http
+    option httpclose
+    monitor-uri /health
     acl http-routers_down nbsrv(<%= backends.first[:name] %>) eq 0
     monitor fail if http-routers_down
 <% end -%>
+<%- end -%>
 
 <% if_p("ha_proxy.resolvers") do |resolvers| -%>
 resolvers default


### PR DESCRIPTION
`expect_proxy_cidrs` is used for dynamically determining whether proxy protocol should be used or not. On AWS the health check and regular traffic are forwarded with or without proxy protocol.

The idea of adding the `expect-proxy` directive CIDRs for AWS load balancer IP addresses as a "marker" for traffic that should become Proxy Protocol, while other traffic (including transparently proxied traffic) remains without Proxy Protocol.

By adding a new health endpoint, when `expect_proxy_cidrs` is set, the operator can select, which endpoint to use for checking the health of HAProxy.