### PR TITLE
Bump keepalived version to 2.3.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,7 +18,7 @@ haproxy/socat-1.8.0.1.tar.gz:
   size: 723747
   object_id: 844e5815-87e6-460a-7cd2-7fbd52d415c3
   sha: sha256:dc350411e03da657269e529c4d49fe23ba7b4610b0b225c020df4cf9b46e6982
-keepalived/keepalived-2.3.1.tar.gz:
-  size: 1210697
-  object_id: a4e911bc-924f-4837-6760-87ecc1217ba0
-  sha: sha256:92f4b69bfd998e2306d1995ad16fdad1b59e70be694c883385c5f55e02c62aa3
+keepalived/keepalived-2.3.2.tar.gz:
+  size: 1225181
+  object_id: ae75621f-bb8c-4de0-5d1e-4ed5e1bc4625
+  sha: sha256:77f4a22e5a23fa8e49b8916acdfb584c864e72905a2f1de2a7f62ed40a896160

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -5,7 +5,7 @@ set -e -x
 mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
-KEEPALIVED_VERSION=2.3.1  # https://keepalived.org/software/keepalived-2.3.1.tar.gz
+KEEPALIVED_VERSION=2.3.2  # https://keepalived.org/software/keepalived-2.3.2.tar.gz
 tar xzvf keepalived/keepalived-${KEEPALIVED_VERSION}.tar.gz
 cd keepalived-${KEEPALIVED_VERSION}/
 


### PR DESCRIPTION

Automatic bump from version 2.3.1 to version 2.3.2, downloaded from https://keepalived.org/software/keepalived-2.3.2.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
