### PR TITLE
Fix acceptance test setup to work on local linux

### DIFF
--- a/acceptance-tests/.gitignore
+++ b/acceptance-tests/.gitignore
@@ -1,1 +1,2 @@
 ginkgo-*.log
+acceptance-tests.test

--- a/acceptance-tests/run-local.sh
+++ b/acceptance-tests/run-local.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+FOCUS="$1"
 
 set -eu
 
@@ -12,8 +13,6 @@ if ! [[ $(git status --porcelain=v1 2>/dev/null | wc -l) -eq 0 ]]; then
     git status
     exit 1
 fi
-
-FOCUS="$1"
 
 docker_mac_check_cgroupsv1() {
     # Force cgroups v1 on Docker for Mac

--- a/acceptance-tests/run-local.sh
+++ b/acceptance-tests/run-local.sh
@@ -31,10 +31,14 @@ docker_mac_check_cgroupsv1() {
 check_required_files() {
   PIDS=""
   REQUIRED_FILE_PATTERNS=(
-    ../ci/scripts/bpm/bpm-release-*.tgz!https://bosh.io/d/github.com/cloudfoundry/bpm-release
     ../ci/scripts/stemcell/bosh-stemcell-*-ubuntu-jammy-*.tgz!https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-jammy-go_agent
     ../ci/scripts/stemcell-bionic/bosh-stemcell-*-ubuntu-bionic-*.tgz!https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-bionic-go_agent
   )
+
+  # BPM downloads as uuid and needs manually specifying file name
+  if [ ! -f "../ci/scripts/bpm/bpm-release-latest.tgz" ] ; then
+    curl -sL https://bosh.io/d/github.com/cloudfoundry/bpm-release -o ../ci/scripts/bpm/bpm-release-latest.tgz
+  fi
 
   for entry in "${REQUIRED_FILE_PATTERNS[@]}"; do
     pattern=$(cut -f1 -d! <<<"$entry")

--- a/ci/scripts/acceptance-tests
+++ b/ci/scripts/acceptance-tests
@@ -16,6 +16,8 @@ fi
 
 cd "${REPO_ROOT:?required}"
 echo "----- Pulling in any git submodules..."
+git config --global --add safe.directory /repo
+git config --global --add safe.directory /repo/src/ttar
 git submodule update --init --recursive --force
 
 # shellcheck disable=SC1091

--- a/ci/scripts/shell
+++ b/ci/scripts/shell
@@ -7,6 +7,8 @@ bpm_release_path=$PWD/bpm/*.tgz
 
 cd ${REPO_ROOT:?required}
 echo "----- Pulling in any git submodules..."
+git config --global --add safe.directory /repo
+git config --global --add safe.directory /repo/src/ttar
 git submodule update --init --recursive --force
 
 echo "----- Starting BOSH"


### PR DESCRIPTION
Few minor fixes to acceptance test scripts and setup so that they can run fine on localhost running linux.