### PR TITLE
Add parameter to set a header containing the client ip

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -405,6 +405,9 @@ properties:
         X-Application-ID: my-custom-header
         MyCustomHeader: 3
 
+  ha_proxy.true_client_ip_header:
+    description: "Header to use to store the client's IP address, as seen from HAProxy. The header will be overwritten if it already exists in the request."
+
   ha_proxy.backend_crt:
     description: "Provides client certificate to backend server to do mutual ssl. Note this only configures the client cert for HTTP backends configured via the backend_servers property or through BOSH links. It is not used with backend servers configured via routed_backend_servers or TCP backends"
     example: |

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -469,6 +469,9 @@ frontend http-in
     http-response add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
+  <%- if_p("ha_proxy.true_client_ip_header") do |header| -%>
+    http-request set-header <%= header %> %[src]
+  <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src -f /var/vcap/jobs/haproxy/config/trusted_domain_cidrs.txt
     <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
@@ -650,6 +653,9 @@ frontend https-in
     <%- rsp_headers.each do |rsp_header, value| -%>
     http-response add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.true_client_ip_header") do |header| -%>
+    http-request set-header <%= header %> %[src]
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src -f /var/vcap/jobs/haproxy/config/trusted_domain_cidrs.txt

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -296,6 +296,16 @@ describe 'config/haproxy.config HTTP frontend' do
     expect(frontend_http).to include('http-request add-header X-Forwarded-Proto "http" if ! xfp_exists')
   end
 
+  context 'when ha_proxy.true_client_ip_header is set' do
+    let(:properties) do
+      { 'true_client_ip_header' => 'X-CF-True-Client-IP' }
+    end
+
+    it 'adds the X-CF-True-Client-IP header' do
+      expect(frontend_http).to include('http-request set-header X-CF-True-Client-IP %[src]')
+    end
+  end
+
   context 'when ha_proxy.https_redirect_all is true' do
     let(:properties) do
       { 'https_redirect_all' => true }

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -663,6 +663,16 @@ describe 'config/haproxy.config HTTPS frontend' do
     expect(frontend_https).to include('http-request add-header X-Forwarded-Proto "https" if ! xfp_exists')
   end
 
+  context 'when ha_proxy.true_client_ip_header is set' do
+    let(:properties) do
+      default_properties.merge({ 'true_client_ip_header' => 'X-CF-True-Client-IP' })
+    end
+
+    it 'adds the X-CF-True-Client-IP header' do
+      expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src]')
+    end
+  end
+
   context 'when ha_proxy.enable_http2 is true' do
     let(:properties) do
       default_properties.merge({ 'enable_http2' => true })


### PR DESCRIPTION
Add property `ha_proxy.true_client_ip_header`. This property allows to define a header name that stores the client [src](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#src) IP address, as seen by HAProxy.