### PR TITLE
Skip ci tests (unit, acceptance) on new releases being pushed

### DIFF
--- a/ci/.ci-ignore
+++ b/ci/.ci-ignore
@@ -6,3 +6,5 @@ docs
 releases
 .final_builds
 manifests/haproxy.yml
+ci/.ci-ignore
+

--- a/ci/.ci-ignore
+++ b/ci/.ci-ignore
@@ -2,8 +2,6 @@ README.md
 CONTRIBUTING.md
 LICENSE.md
 ci/README.md
-ci/release_notes_template.md
-ci/release_notes.md
 docs
 releases
 .final_builds

--- a/ci/.ci-ignore
+++ b/ci/.ci-ignore
@@ -5,3 +5,6 @@ ci/README.md
 ci/release_notes_template.md
 ci/release_notes.md
 docs
+releases
+.final_builds
+manifests/haproxy.yml


### PR DESCRIPTION
When a new[ release is released,](https://github.com/cloudfoundry/haproxy-boshrelease/commit/05469c6fb317103d4ca7cedc754374e2e7a7e800) there are some updates to `.final_builds` and similar. Skip CI, as to create new release, things had to be merged first, meaning they have passed CI.

Cleanup ci-ignore - remove old files.