### PR TITLE
Bump socat version to 1.8.0.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,10 +14,10 @@ haproxy/pcre2-10.45.tar.gz:
   size: 2715958
   object_id: 438a6053-a6b9-49ba-7215-13396893b187
   sha: sha256:0e138387df7835d7403b8351e2226c1377da804e0737db0e071b48f07c9d12ee
-haproxy/socat-1.8.0.2.tar.gz:
-  size: 724311
-  object_id: 2ecd406a-4547-4441-7d85-53a5d53d227d
-  sha: sha256:e9498367cb765d44bb06be9709c950f436b30bf7071a224a0fee2522f9cbb417
+haproxy/socat-1.8.0.3.tar.gz:
+  size: 744553
+  object_id: 5a0cc86e-dd69-4089-73f7-cdf7297c1377
+  sha: sha256:a9f9eb6cfb9aa6b1b4b8fe260edbac3f2c743f294db1e362b932eb3feca37ba4
 keepalived/keepalived-2.3.2.tar.gz:
   size: 1225181
   object_id: ae75621f-bb8c-4de0-5d1e-4ed5e1bc4625

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -6,7 +6,7 @@ LUA_VERSION=5.4.7  # https://www.lua.org/ftp/lua-5.4.7.tar.gz
 
 PCRE_VERSION=10.45  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz
 
-SOCAT_VERSION=1.8.0.2  # http://www.dest-unreach.org/socat/download/socat-1.8.0.2.tar.gz
+SOCAT_VERSION=1.8.0.3  # http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz
 
 HAPROXY_VERSION=2.8.14  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.14.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 1.8.0.2 to version 1.8.0.3, downloaded from http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
