### PR TITLE
fix: properly check if TCP should be drained

### DIFF
--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -63,7 +63,9 @@ echo "disable frontend health_check_http_url_proxy_protocol" | /usr/local/bin/so
     }
   end -%>
 <%- tcp.each do |tcp_proxy| -%>
+<%- unless tcp_proxy.fetch("health_check_http", nil).nil? -%>
 echo "disable frontend health_check_http_tcp-<%= tcp_proxy["name"] %>" | /usr/local/bin/socat stdio unix-connect:${sockfile}
+<%- end -%>
 <%- end -%>
 
 <%- if p("ha_proxy.enable_health_check_http") || tcp.size > 0 -%>


### PR DESCRIPTION
When there is no HTTP health-check for a TCP frontend the drain logic doesn't work as the frontend it tries to disable does not exist. This commit makes the statement to disable the frontend during the draining depend on whether the HTTP health-heck for that TCP frontend is enbaled and if not excludes the drain logic for it.

Resolves: https://github.com/cloudfoundry/haproxy-boshrelease/issues/788