### PR TITLE
Bump lua version to 5.4.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,10 @@ haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4
   sha: sha256:6ba2136e98b9a436488be67a54a5295f55f38090157d09df0154dda493ac5815
-haproxy/lua-5.4.7.tar.gz:
-  size: 374097
-  object_id: 6829cdad-976c-4cd5-765b-b8f4c106e268
-  sha: sha256:9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
+haproxy/lua-5.4.8.tar.gz:
+  size: 374332
+  object_id: 11cb896a-5089-432c-7652-fb5504bd13ff
+  sha: sha256:4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
 haproxy/pcre2-10.45.tar.gz:
   size: 2715958
   object_id: 438a6053-a6b9-49ba-7215-13396893b187

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 
-LUA_VERSION=5.4.7  # https://www.lua.org/ftp/lua-5.4.7.tar.gz
+LUA_VERSION=5.4.8  # https://www.lua.org/ftp/lua-5.4.8.tar.gz
 
 PCRE_VERSION=10.45  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 5.4.7 to version 5.4.8, downloaded from https://www.lua.org/ftp/lua-5.4.8.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
