### PR TITLE
Bump pcre2 version to 10.46

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,10 @@ haproxy/lua-5.4.8.tar.gz:
   size: 374332
   object_id: 11cb896a-5089-432c-7652-fb5504bd13ff
   sha: sha256:4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
-haproxy/pcre2-10.45.tar.gz:
-  size: 2715958
-  object_id: 438a6053-a6b9-49ba-7215-13396893b187
-  sha: sha256:0e138387df7835d7403b8351e2226c1377da804e0737db0e071b48f07c9d12ee
+haproxy/pcre2-10.46.tar.gz:
+  size: 2718545
+  object_id: 0dc750e8-9696-4429-49ca-b32e438b478f
+  sha: sha256:8d28d7f2c3b970c3a4bf3776bcbb5adfc923183ce74bc8df1ebaad8c1985bd07
 haproxy/socat-1.8.0.3.tar.gz:
   size: 744553
   object_id: 5a0cc86e-dd69-4089-73f7-cdf7297c1377

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 LUA_VERSION=5.4.8  # https://www.lua.org/ftp/lua-5.4.8.tar.gz
 
-PCRE_VERSION=10.45  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz
+PCRE_VERSION=10.46  # https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.46/pcre2-10.46.tar.gz
 
 SOCAT_VERSION=1.8.0.3  # http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz
 


### PR DESCRIPTION

Automatic bump from version 10.45 to version 10.46, downloaded from https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.46/pcre2-10.46.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
