### PR TITLE
Bump haproxy version to 2.8.16

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.8.15.tar.gz:
-  size: 4418838
-  object_id: 62c4c00d-e1ab-4dc0-608a-c55e4a0a77bb
-  sha: sha256:98f0551b9c3041a87869f4cd4e1465adf6fbef2056e83aabea92106032585242
+haproxy/haproxy-2.8.16.tar.gz:
+  size: 4429238
+  object_id: b5d1e4e1-03b6-40c8-5ba5-ba05cecee194
+  sha: sha256:6eb4d3cc298af89613fc6cb175530436e1e463d368e43401a60357a7a12d15ab
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.46  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.0.3  # http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz
 
-HAPROXY_VERSION=2.8.15  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.15.tar.gz
+HAPROXY_VERSION=2.8.16  # https://www.haproxy.org/download/2.8/src/haproxy-2.8.16.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.8.15 to version 2.8.16, downloaded from https://www.haproxy.org/download/2.8/src/haproxy-2.8.16.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 2.8.16](https://www.haproxy.org/download/2.8/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 2.8.16](https://www.haproxy.org/bugs/bugs-2.8.16.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 2.8.16 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-2.8.16%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 2.8.16 and 2.8.15</summary>

```
2025/10/03 : 2.8.16
    - BUG/MINOR: cli: Issue an error when too many args are passed for a command
    - BUG/MAJOR: listeners: transfer connection accounting when switching listeners
    - MINOR: applet: add appctx_schedule() macro
    - BUG/MINOR: dns: add tempo between 2 connection attempts for dns servers
    - CLEANUP: dns: remove unused dns_stream_server struct member
    - BUG/MINOR: dns: prevent ds accumulation within dss
    - BUG/MINOR: mux-h1: Don't pretend connection was released for TCP>H1>H2 upgrade
    - BUG/MINOR: mux-h1: Fix trace message in h1_detroy() to not relay on connection
    - BUG/MINOR: proxy: only use proxy_inc_fe_cum_sess_ver_ctr() with frontends
    - MINOR: quic: extend return value during TP parsing
    - BUG/MINOR: quic: use proper error code on missing CID in TPs
    - BUG/MINOR: quic: use proper error code on invalid server TP
    - BUG/MINOR: quic: reject retry_source_cid TP on server side
    - BUG/MINOR: quic: use proper error code on invalid received TP value
    - BUG/MINOR: quic: fix TP reject on invalid max-ack-delay
    - BUG/MINOR: quic: reject invalid max_udp_payload size
    - BUG/MINOR: cli: fix too many args detection for commands
    - BUG/MINOR: threads: fix soft-stop without multithreading support
    - BUG/MINOR: hlua: Fix Channel:data() and Channel:line() to respect documentation
    - BUG/MINOR: sink: detect and warn when using "send-proxy" options with ring servers
    - DOC: ring: refer to newer RFC5424
    - DOC: config: restore default values for resolvers hold directive
    - DOC: config: recommend disabling libc-based resolution with resolvers
    - BUG/MINOR: h3: don't insert more than one Host header
    - CLEANUP: quic: Useless BIO_METHOD initialization
    - MINOR: quic: Add useful error traces about qc_ssl_sess_init() failures
    - MEDIUM: hlua: Add function to change the body length of an HTTP Message
    - BUG/MINOR: mux-h2: Reset streams with NO_ERROR code if full response was already sent
    - BUILD: makefile: enable backtrace by default on musl
    - BUG/MINOR: h3: Set HTX flags corresponding to the scheme found in the request
    - REGTESTS: Make the script testing conditional set-var compatible with Vtest2
    - CI: vtest: Rely on VTest2 to run regression tests
    - REGTESTS: Explicitly allow failing shell commands in some scripts
    - BUG/MINOR: limits: compute_ideal_maxconn: don't cap remain if fd_hard_limit=0
    - BUG/MINOR: init: relax LSTCHK_NETADM checks for non root
    - MINOR: compiler: add __nonstring macro
    - BUG/MEDIUM: httpclient: Throw an error if an lua httpclient instance is reused
    - DOC: hlua: Add a note to warn user about httpclient object reuse
    - DOC: hlua: fix a few typos in HTTPMessage.set_body_len() documentation
    - BUG/MINOR: mux-quic: do not decode if conn in error
    - BUG/MEDIUM: check: Requeue healthchecks on I/O events to handle check timeout
    - BUG/MEDIUM: fd: Use the provided tgid in fd_insert() to get tgroup_info
    - BUG/MINOR: config/server: reject QUIC addresses
    - BUG/MEDIUM: check: Set SOCKERR by default when a connection error is reported
    - BUG/MEDIUM: ssl/clienthello: ECDSA with ssl-max-ver TLSv1.2 and no ECDSA ciphers
    - MINOR: http: add a function to validate characters of :authority
    - BUG/MEDIUM: h2/h3: reject some forbidden chars in :authority before reassembly
    - BUG/MEDIUM: h1/h2/h3: reject forbidden chars in the Host header field
    - DOC: config: prefer-last-server: add notes for non-deterministic algorithms
    - BUG/MINOR: stream: Avoid recursive evaluation for unique-id based on itself
    - BUG/MINOR: log: Be able to use %ID alias at anytime of the stream's evaluation
    - DOC: configuration: add details on prefer-client-ciphers
    - BUG/MINOR: quic: wrong QUIC_FT_CONNECTION_CLOSE(0x1c) frame encoding
    - SCRIPTS: drop the HTML generation from announce-release
    - BUG/MEDIUM: hlua: Forbid any L6/L7 sample fetche functions from lua services
    - BUG/MEDIUM: mux-h2: Properly handle connection error during preface sending
    - BUG/MINOR: jwt: Copy input and parameters in dedicated buffers in jwt_verify converter
    - DOC: Fix 'jwt_verify' converter doc
    - BUG/MINOR: hlua: Skip headers when a receive is performed on an HTTP applet
    - BUG/MEDIUM: hlua: Report to SC when data were consumed on a lua socket
    - BUG/MEDIUM: hlua: Report to SC when output data are blocked on a lua socket
    - BUG/MEDIUM: dns: Reset reconnect tempo when connection is finally established
    - BUG/MINOR: hlua: take default-path into account with lua-load-per-thread
    - DOC: management: clarify usage of -V with -c
    - BUG/MINOR: listener: really assign distinct IDs to shards
    - BUG/MEDIUM: http-client: Don't wake http-client applet if nothing was xferred
    - BUG/MEDIUM: http-client: Properly inc input data when HTX blocks are xferred
    - BUG/MEDIUM: http-client: Ask for more room when request data cannot be xferred
    - BUG/MINOR: http-client: Ignore 1XX interim responses in non-HTX mode
    - BUG/MINOR: http-client: Reject any 101-switching-protocols response
    - BUG/MEDIUM: http-client: Drain the request if an early response is received
    - BUG/MEDIUM: http-client: Notify applet has more data to deliver until the EOM
    - BUG/MINOR: applet: Don't trigger BUG_ON if the tid is not on appctx init
    - BUG/MINOR: halog: exit with error when some output filters are set simultaneosly
    - BUG/MEDIUM: threads: Disable the workaround to load libgcc_s on macOS
    - DOC: list missing global QUIC settings
    - BUILD: compat: always set _POSIX_VERSION to ease comparisons
    - BUG/MINOR: stick-table: cap sticky counter idx with tune.nb_stk_ctr instead of MAX_SESS_STKCTR
    - BUG/MEDIUM: ssl: Fix 0rtt to the server
    - BUG/MEDIUM: ssl: fix build with AWS-LC
    - BUG/MINOR: init: Initialize random seed earlier in the init process
    - DOC: management: fix typo in commit f4f93c56
    - DOC: config: recommend single quoting passwords
    - BUG/MEDIUM: http-client: Test HTX_FL_EOM flag before commiting the HTX buffer
    - BUG/MINOR: mux-h1: fix wrong lock label
    - BUG/MINOR: quic: do not emit probe data if CONNECTION_CLOSE requested
    - BUG/MINOR: acl: set arg_list->kw to aclkw->kw string literal if aclkw is found
    - DOC: unreliable sockpair@ on macOS
    - DOC: configuration: confuse "strict-mode" with "zero-warning"
    - MINOR: doc: add missing statistics column
    - MINOR: doc: add missing statistics column
    - BUG/MEDIUM: server: Duplicate healthcheck's alpn inherited from default server
    - BUG/MINOR: quic: fix room check if padding requested
    - BUG/MINOR: haproxy: be sure not to quit too early on soft stop
    - BUILD: acl: silence a possible null deref warning in parse_acl_expr()
    - OPTIM: check: do not delay MUX for ALPN if SSL not active
    - BUG/MEDIUM: checks: fix ALPN inheritance from server
    - BUG/MEDIUM: h1: Allow reception if we have early data
    - BUG/MEDIUM: ssl: create the mux immediately on early data
    - BUG/MINOR: activity: fix reporting of task latency
    - BUG/MINOR: ocsp: Crash when updating CA during ocsp updates
    - BUG/MINOR: resolvers: always normalize FQDN from response
    - BUG/MINOR: server: Update healthcheck when server settings are changed via CLI
    - BUG/MEDIUM: ssl: ca-file directory mode must read every certificates of a file
    - BUG/MINOR: h3: Fix errors introduced because of failed backport
    - Revert "BUG/MINOR: config/server: reject QUIC addresses"
    - DOC: config: clarify some known limitations of the json_query() converter
    - BUG/CRITICAL: mjson: fix possible DoS when parsing numbers
    - BUG/MINOR: h2: forbid 'Z' as well in header field names checks
    - BUG/MINOR: h3: forbid 'Z' as well in header field names checks
    - Revert "BUILD: makefile: enable backtrace by default on musl"


```

</details>