### PR TITLE
Bump haproxy version to 3.2.22

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.21.tar.gz:
-  size: 5159225
-  object_id: 123589cc-f96b-4ce3-438c-8c08009c4af2
-  sha: sha256:0cb8818a26c5f888e0cb1c40f1b3acb9fb952527d1733f769ce688fedd680339
+haproxy/haproxy-3.2.22.tar.gz:
+  size: 5166368
+  object_id: 32f6ecc2-2105-4dd0-6a7d-14c427c30ab5
+  sha: sha256:afca3a26d573df53d0e1fc475dcd743ec5875e038e1476c80e871d70228ca2da
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.3  # http://www.dest-unreach.org/socat/download/socat-1.8.1.3.tar.gz
 
-HAPROXY_VERSION=3.2.21  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.21.tar.gz
+HAPROXY_VERSION=3.2.22  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.22.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 3.2.21 to version 3.2.22, downloaded from https://www.haproxy.org/download/3.2/src/haproxy-3.2.22.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 3.2.22](https://www.haproxy.org/download/3.2/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 3.2.22](https://www.haproxy.org/bugs/bugs-3.2.22.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 3.2.22 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-3.2.22%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 3.2.22 and 3.2.21</summary>

```
2026/07/29 : 3.2.22
    - BUG/MEDIUM: h3: fix parser desync on error with multiple frames
    - BUG/MINOR: mux_quic: prevent multiple STOP_SENDING emission per stream
    - BUG/MEDIUM: fd: Fix a deadlock when closing other tgroups fds
    - BUG/MINOR: sample: Fix a possible underflow on be2hex for large chunk size
    - BUG/MINOR: stream: Fix custom timeouts initialization when setting backend
    - BUG/MINOR: stream: Fix custom max-retries initialization when setting backend
    - BUG/MINOR: http-conv: Make url-dec failed if no space for trailing null byte
    - BUG/MINOR: hlua: Apply socket timeout on server side only
    - REORG: stconn: Move sc_chk_rcv() from sc_strm.h to stconn.c
    - BUG/MEDIUM: applet: Reenable reads in applet context if requesting a connection
    - MINOR: stats: factor the proxy vs scope check into its own function
    - BUG/MEDIUM: stats: subject "stats admin" accesses to "stats scope" filtering
    - BUG/MINOR: shctx: fix shctx_row_data_get() when offset exceeds a block
    - MINOR: shctx: clamp shctx_row_data_get() reads against the offset
    - BUG/MEDIUM: cache: reattach the row when a secondary entry is incomplete
    - BUG/MEDIUM: stats: Ensure that Origin is valid on POSTs
    - DOC: stats: Document that stats admin is vulnerable to a CSRF attack
    - BUG/MEDIUM: ssl-gencert: Don't forget to free memory when done
    - BUG/MEDIUM: protobuf: adjust sample size capacity after pointer shift
    - BUG/MEDIUM: protobuf: fix nested path bypass in field lookup
    - BUG/MINOR: ssl: fix proxy lookup for show ssl sni
    - REGTESTS: protobuf: add regression test for nested vs flat paths
    - BUG/MINOR: mux-h1: Don't delay send if message with c-l was fully sent
    - BUG/MEDIUM: sample: Adjust sample size capacity after pointer shift for bytes()
    - BUG/MEDIUM: sample: Adjust sample size capacity after pointer shift for ltrim()
    - BUG/MINOR: sample: Fix bytes() when length it greater than remaining data
    - BUG/MEDIUM: proxy: protect "show servers ..." against server deletion
    - BUG/MINOR: resolvers: do not index resolvers names in the proxies
    - REORG: h1-htx: Move h1 headers map in h1-htx
    - BUG/MEDIUM: mux-h1: Always adjust case for all outgoing headers as expected
    - BUG/MINOR: http-htx: fix the length moved when removing a header value
    - BUG/MEDIUM: http-fetch: don't parse a non-HTTP check buffer as an HTX message
    - BUG/MEDIUM: http-fetch: reject a negative capture id in capture.{req,res}.hdr
    - BUG/MINOR: http: fix an out-of-bounds read in http_get_host_port() on empty host
    - BUG/MINOR: http-htx: check the trash allocation in http_scheme_based_normalize()
    - BUG/MINOR: h1: report the right error position on authority/host mismatch
    - BUG/MINOR: h2: don't use a block pointer to roll back a partial HTX conversion
    - BUG/MINOR: http-ana: fix a one-byte over-read in the client-side cookie parser
    - BUG/MINOR: http-act: fix a double free of the regex on a rule parsing error
    - BUG/MINOR: http-act: fix a double free of the map reference on a parsing error
    - BUG/MINOR: http-act: restore the response buffer state in the early-hint action
    - BUG/MINOR: http-act: reject a negative capture id in the capture actions
    - BUG/MINOR: http-htx: check the strdup() of the "lf-string" http reply argument
    - BUG/MINOR: htx: Perform raw copy for messages of same size in htx_copy_msg()
    - BUG/MINOR: htx: Transfer HTX_FL_EOM flag on success in htx_append_msg()
    - BUG/MINOR: http-rules: fix release of a failed "set-cookie-fmt" redirect rule
    - BUG/MINOR: slz: do not read past the end of the input around the match loop
    - CLEANUP: slz: fix the documented worst case size of flush() and finish()
    - BUG/MINOR: slz: use the exact switch cost for the last literals of a block
    - BUG/MEDIUM: slz: bound the bits wasted by the 9-bit literals
    - BUG/MINOR: slz: do not append a block to an already finished stream
    - BUG/MINOR: slz: fix the adler32 accumulators signedness on 32-bit
    - BUG/MINOR: slz: avoid undefined shifts when building the word byte by byte
    - CLEANUP: slz: clarify that the size promise applies to the stream, not to a call
    - BUG/MEDIUM: peers: check the available room before encoding dict values
    - BUG/MEDIUM: sample: reject the deprecated protobuf group wire types
    - BUG/MAJOR: ssl/ocsp: lock the OCSP response around reads in the stapling callback
    - MEDIUM: stream: Introduce stream_set_srv_target()
    - BUG/MEDIUM: server: Properly check for streams before deletion
    - MINOR: server: improve parsing error for server-template
    - BUG/MINOR: server: duplicate server alt_proto in srv_settings_cpy()
    - BUG/MINOR: server: fix check reuse-pool in srv_settings_cpy()


```

</details>