### PR TITLE
Bump haproxy version to 3.2.23

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.22.tar.gz:
-  size: 5166368
-  object_id: 32f6ecc2-2105-4dd0-6a7d-14c427c30ab5
-  sha: sha256:afca3a26d573df53d0e1fc475dcd743ec5875e038e1476c80e871d70228ca2da
+haproxy/haproxy-3.2.23.tar.gz:
+  size: 5178167
+  object_id: 3458abd0-40ca-498b-570e-c93977e57d7c
+  sha: sha256:82d14ef33571e4edeb9197516c0d058a3775fb80541e46afe4377428e461fef0
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.3  # http://www.dest-unreach.org/socat/download/socat-1.8.1.3.tar.gz
 
-HAPROXY_VERSION=3.2.22  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.22.tar.gz
+HAPROXY_VERSION=3.2.23  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.23.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 3.2.22 to version 3.2.23, downloaded from https://www.haproxy.org/download/3.2/src/haproxy-3.2.23.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 3.2.23](https://www.haproxy.org/download/3.2/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 3.2.23](https://www.haproxy.org/bugs/bugs-3.2.23.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 3.2.23 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-3.2.23%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 3.2.23 and 3.2.22</summary>

```
2026/08/27 : 3.2.23
    - BUG/MINOR: cli: use the current argument to parse the FD spec in "show fd"
    - BUG/MEDIUM: filter: Disable auto-close on channel during TCP payload filtering
    - BUG/MINOR: server: check strdup return value on server ID
    - BUG/MINOR: proxy: fix default-server leak on post-parsing cleanup
    - BUG/MEDIUM: hpack: encode long methods and schemes using the long form
    - BUG/MINOR: hlua: use a local buffer to format the socket addresses
    - BUG/MEDIUM: spoe: clear the applet pointer when the applet fails to start
    - BUG/MINOR: mux-fcgi: don't call fcgi_strm_destroy() on a NULL stream
    - BUG/MEDIUM: http-ana: don't crash on "keep-query" in a response redirect
    - BUG/MEDIUM: stick-tables: use the same bucket for string keys with a NUL
    - BUG/MEDIUM: sock: bound the recvmsg() length when receiving old sockets
    - BUG/MEDIUM: http-ana: check the cookie rewrite result before moving the offsets
    - BUG/MINOR: mux-fcgi: sanitize the STDERR records before logging them
    - MINOR: log/tools: fix ambiguous comments for some log encoding helpers
    - BUG/MEDIUM: log: always reserve room for trailing 0 when using CBOR encoding helpers
    - BUG/MEDIUM: acme: don't delete a NULL token from the map
    - BUG/MINOR: ssl: reject server certificate names containing a NUL byte
    - BUG/MINOR: acme: restrict the permissions of the generated account key
    - BUG/MEDIUM: ssl: require a full-length AEAD tag when decrypting with AES-GCM
    - BUG/MINOR: connection: reserve the whole CRC32C TLV before saving its pointer
    - BUG/MEDIUM: session: don't release a reversed connection twice on error
    - BUG/MINOR: lb-chash: bound the walk when the saved cursor changed tree
    - BUG/MINOR: debug: only dump the trace once in __BUG_ON_ONCE()
    - BUG/MINOR: mux-h2: strip the userinfo when deriving :authority for a server
    - BUG/MEDIUM: quic: prevent out-of-bound read on wrapping CRYPTO content
    - BUG/MEDIUM: lua: resume Channel:send() from the unsent part of the string
    - BUG/MEDIUM: hlua_fcn: ensure systematic bref cleanup for patref list iterator
    - DOC: config: clarify req.ssl_sni
    - BUG/MEDIUM: cache: retain the primary or secondary entry only when detaching its row
    - BUG/MEDIUM: cache: do not release an entry under the cache read lock
    - BUG/MINOR: ssl: reject an embedded NUL in the ssl_*_dn(entry) fetches
    - BUG/MINOR: ssl: reject an embedded NUL in the full-DN ssl_*_dn() fetches
    - BUG/MINOR: quic: avoid a division by zero in the BBR pacing interval
    - BUG/MINOR: server: fix off-by-one error when parsing and copying source port range
    - BUG/MEDIUM: http: fix authority parsing for absolute-form URI with empty path
    - BUG/MEDIUM: bwlim: fix a stick-table entry leak in shared mode
    - BUG/MINOR: payload: fix handshake length off-by-4 in ssl_hello_sni/alpn
    - BUG/MINOR: spoe: check snprintf() return value in spoe_set_var/spoe_unset_var
    - BUG/MINOR: qpack: missing shift count check in qpack_get_varint() (UB)
    - BUG/MINOR: log: fix double-free error when error in parse_loger occurs
    - BUG/MINOR: conn: Do not check 'sess_el' list on frontend connections in __trace_enabled
    - BUG/MINOR: ssl: Fix leak of X509_NAME in traces
    - BUG/MINOR: ssl: release the previous client cert reference at depth > 0
    - BUG/MEDIUM: ssl: Fix unprotected 'ssl_sock_choose_sni_ctx' calls
    - BUG/MEDIUM: ssl: enforce tune.ssl.lifetime across TLS1.3 session renewals
    - BUG/MINOR: ssl: apply tune.ssl.lifetime to TLS1.3 sessions on BoringSSL/AWS-LC
    - BUILD: ssl: disable the TLS1.3 session timeout clamp on wolfSSL
    - BUG/MEDIUM: ssl: isolate TLS session resumption per X509 server certificate
    - BUG/MINOR: ssl: isolate TLS session resumption per crt-list filter
    - BUG/MEDIUM: ssl: isolate TLS session resumption per authentication policy
    - BUILD: ssl: avoid a potential null-dereference warning on OpenSSL 1.0.2
    - BUG/MINOR: ssl/cli: fix frontend-not-found detection in 'show ssl sni -f'
    - BUG/MINOR: resolvers: accept fields at the response boundary
    - BUG/MEDIUM: mux-fcgi: check the room left before appending the index
    - BUG/MINOR: wurfl: fix memory leak of information list and patch strings at deinit
    - BUG/MINOR: config: Check buffer pool creation for failures
    - BUG/MINOR: acme: NULL check on my_strndup()
    - BUG/MINOR: ot: removed dead code in flt_ot_parse_cfg_str()
    - BUG/MINOR: http-fetch: fix smp_fetch_hdr_ip()'s handling of brackets for IPv6
    - BUG/MINOR: http-fetch: make http_first_req() check for HTTP first
    - BUG/MINOR: http-act: set-status() must check the response message, not the request
    - BUG/MINOR: tools: fix memory leak in env_expand() error path
    - BUG/MINOR: auth: free user groups on error paths in userlist_postinit()
    - BUG/MEDIUM: tools: make string encoding possible to fail instead of truncating
    - BUG/MINOR: cfgcond: make KQUEUE check for GTUNE_USE_KQUEUE not GTUNE_USE_EPOLL
    - BUG/MINOR: mqtt: connack parser returns MQTT_NEED_MORE_DATA on unknown property
    - BUG/MINOR: mqtt: connect parser uses wrong bit field for TOPIC_ALIAS_MAXIMUM
    - BUG/MINOR: mqtt: connack parser uses wrong bit for SUBSCRIPTION_IDENTIFIERS_AVAILABLE
    - BUG/MINOR: mqtt: fix PUBLISH flags validation that want all bits to be set
    - BUG/MINOR: mux-h2: harden h2_dump_h2s_info() against potentially null h2s->sd
    - BUG/MEDIUM: mux-h1: close the connection on a short content-length
    - MEDIUM: mux-h2: don't report EOM on a short content-length message
    - BUG/MEDIUM: connection: fix an infinite loop in the fc_pp_tlv() fetch
    - BUG/MEDIUM: sink: do not hold the sft lock around ring_dispatch_messages()
    - MINOR: sample: add new converter has_ctl() to detect control characters
    - REGTESTS: converters: use connection: close in the has_ctl() test
    - BUG/MEDIUM: cache: ignore cache on redundant origin/referer
    - BUG/MINOR: fcgi-app: allow explicit filter declaration with non-cache/non-compression filters
    - BUG/MINOR: flt-http-comp: Don't read next block to detect end of data
    - BUG/MEDIUM: sink: initialize the settings of the implicit log server
    - BUG/MEDIUM: sink: do not create one implicit ring per logger copy


```

</details>